### PR TITLE
DOI 759 ev dashboard packages npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,4 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
 
       - name: Publish packages
-        run: node common/scripts/install-run-rush.js publish --include-all
+        run: node common/scripts/install-run-rush.js publish --publish --include-all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - 'DOI-759-ev-dashboard-client-npm-publish'
+      - 'publish'
 
 jobs:
   cancel-previous:
@@ -38,7 +38,6 @@ jobs:
 
       - name: Check for change files
         run: node common/scripts/install-run-rush.js change -v
-        continue-on-error: true
 
       - name: Bump version
         run: node common/scripts/install-run-rush.js version --bump

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '14'
+          registry-url: https://registry.npmjs.org/
 
       - name: Rush install
         run: node common/scripts/install-run-rush.js install
@@ -42,3 +43,5 @@ jobs:
 
       - name: Publish packages
         run: node common/scripts/install-run-rush.js publish --publish --include-all
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v2-beta
-         with:
+        with:
           node-version: '14'
 
       - name: Rush install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,3 +45,4 @@ jobs:
         run: node common/scripts/install-run-rush.js publish --publish --include-all
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,12 @@ jobs:
       - name: Rush install
         run: node common/scripts/install-run-rush.js install
 
+      - name: Run test
+        run: node common/scripts/install-run-rush.js test --verbose
+
       - name: Build packages
         run: node common/scripts/install-run-rush.js build --verbose
+
 
       - name: Set npm credentials
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish
+
+on:
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  cancel-previous:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+  publish-packages:
+    runs-on: ubuntu-latest
+    needs: cancel-previous
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2-beta
+         with:
+          node-version: '14'
+
+      - name: Rush install
+        run: node common/scripts/install-run-rush.js install
+
+      - name: Rush build
+        run: node common/scripts/install-run-rush.js build --verbose
+
+      - name: Set npm credentials
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
+
+      - name: Rush build
+        run: node common/scripts/install-run-rush.js publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
       - '*'
@@ -31,11 +28,11 @@ jobs:
       - name: Rush install
         run: node common/scripts/install-run-rush.js install
 
-      - name: Rush build
+      - name: Build packages
         run: node common/scripts/install-run-rush.js build --verbose
 
       - name: Set npm credentials
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
 
-      - name: Rush build
-        run: node common/scripts/install-run-rush.js publish
+      - name: Publish packages
+        run: node common/scripts/install-run-rush.js publish --include-all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish
 
 on:
+  push:
+    branches:
+      - 'DOI-759-ev-dashboard-client-npm-publish'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
 
       - name: Publish packages
-        run: node common/scripts/install-run-rush.js publish --publish --include-all
+        run: node common/scripts/install-run-rush.js publish --apply --publish --include-all
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish
 
 on:
+  push:
+    branches:
+      - '*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,12 @@ jobs:
           node-version: '14'
           registry-url: https://registry.npmjs.org/
 
+      - name: Check for change files
+        run: node common/scripts/install-run-rush.js change -v 
+      
+      - name: Bump version 
+        run: node common/scripts/install-run-rush.js version --bump 
+      
       - name: Rush install
         run: node common/scripts/install-run-rush.js install
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - 'DOI-759-ev-dashboard-client-npm-publish'
-  pull_request:
-    branches:
-      - '*'
+
 jobs:
   cancel-previous:
     name: 'Cancel Previous Runs'
@@ -29,12 +27,6 @@ jobs:
           node-version: '14'
           registry-url: https://registry.npmjs.org/
 
-      - name: Check for change files
-        run: node common/scripts/install-run-rush.js change -v 
-      
-      - name: Bump version 
-        run: node common/scripts/install-run-rush.js version --bump 
-      
       - name: Rush install
         run: node common/scripts/install-run-rush.js install
 
@@ -43,6 +35,13 @@ jobs:
 
       - name: Run test
         run: node common/scripts/install-run-rush.js test --verbose
+
+      - name: Check for change files
+        run: node common/scripts/install-run-rush.js change -v
+        continue-on-error: true
+
+      - name: Bump version
+        run: node common/scripts/install-run-rush.js version --bump
 
       - name: Set npm credentials
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,12 +31,11 @@ jobs:
       - name: Rush install
         run: node common/scripts/install-run-rush.js install
 
-      - name: Run test
-        run: node common/scripts/install-run-rush.js test --verbose
-
       - name: Build packages
         run: node common/scripts/install-run-rush.js build --verbose
 
+      - name: Run test
+        run: node common/scripts/install-run-rush.js test --verbose
 
       - name: Set npm credentials
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc

--- a/.prettierignore
+++ b/.prettierignore
@@ -106,3 +106,5 @@ lib
 # Root tsconfig.json has a bunch of comments and prettier messes up the spacing
 /tsconfig.json
 
+# Github workflow
+.github/workflows/*.yml

--- a/apps/asset-operator-cli/package.json
+++ b/apps/asset-operator-cli/package.json
@@ -37,5 +37,9 @@
     "ts-jest": "~26.5.4",
     "typescript": "~4.2.3",
     "web3-utils": "^1.3.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/apps/asset-operator-cli/package.json
+++ b/apps/asset-operator-cli/package.json
@@ -1,11 +1,19 @@
 {
-  "name": "@ev-dashboard-client/asset-operator-cli",
+  "name": "@energyweb/ev-asset-operator-cli",
   "version": "1.0.0",
   "description": "A cli for AssetOperators to enable their assets to participate in the ev-dashboard.",
   "scripts": {
     "build": "rimraf dist && tsc",
     "test": "pnpm run start-rpc -- \"jest\"",
     "start-rpc": "run-with-testrpc -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000"
+  },
+  "homepage": "https://github.com/energywebfoundation/ev-dashboard-client/#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/ev-dashboard-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/energywebfoundation/ev-dashboard-client/issues"
   },
   "author": "Energy Web",
   "license": "GPL-3.0-or-later",
@@ -16,14 +24,14 @@
     "ev-cli": "dist/cli.js"
   },
   "dependencies": {
-    "@ev-dashboard-client/asset-registrar": "1.0.0",
-    "@ev-dashboard-client/did-hydrator": "1.0.0",
-    "@ev-dashboard-client/key-manager": "1.0.0",
+    "@energyweb/ev-registry": "1.0.0",
+    "@energyweb/ev-did-hydrator": "1.0.0",
+    "@energyweb/ev-key-manager": "1.0.0",
     "@ew-did-registry/keys": "0.0.1-alpha.694.1",
     "yargs": "~16.2.0"
   },
   "devDependencies": {
-    "@ev-dashboard-client/contract-deployer": "1.0.0",
+    "@energyweb/ev-contract-deployer": "1.0.0",
     "@rushstack/eslint-config": "~2.3.2",
     "@types/jest": "~26.0.21",
     "@types/node": "~14.14.35",

--- a/apps/asset-operator-cli/src/cli.ts
+++ b/apps/asset-operator-cli/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { EvRegistry } from '@ev-dashboard-client/asset-registrar';
-import { KeyManager } from '@ev-dashboard-client/key-manager';
+import { EvRegistry } from '@energyweb/ev-registry';
+import { KeyManager } from '@energyweb/ev-key-manager';
 import { Keys } from '@ew-did-registry/keys';
 import * as yargs from 'yargs';
 

--- a/apps/asset-operator-cli/test/cli.test.ts
+++ b/apps/asset-operator-cli/test/cli.test.ts
@@ -4,8 +4,8 @@ import {
   GANACHE_PORT,
   evDashboardRegistry,
   ocnRegistry
-} from '@ev-dashboard-client/contract-deployer';
-import { EvRegistry } from '@ev-dashboard-client/asset-registrar';
+} from '@energyweb/ev-contract-deployer';
+import { EvRegistry } from '@energyweb/ev-registry';
 import { execSync } from 'child_process';
 import { Keys } from '@ew-did-registry/keys';
 import { toHex } from 'web3-utils';

--- a/apps/asset-operator-server/package.json
+++ b/apps/asset-operator-server/package.json
@@ -1,18 +1,26 @@
 {
-  "name": "@ev-dashboard-client/asset-operator-server",
+  "name": "@energyweb/ev-asset-operator-server",
   "version": "1.0.0",
   "description": "HTTP API for AssetOperators to enable their assets to participate in the ev-dashboard.",
   "scripts": {
     "build": "rimraf dist && tsc",
     "start": "node dist/index.js"
   },
+  "homepage": "https://github.com/energywebfoundation/ev-dashboard-client/#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/ev-dashboard-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/energywebfoundation/ev-dashboard-client/issues"
+  },
   "author": "Energy Web",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@ev-dashboard-client/asset-registrar": "1.0.0",
-    "@ev-dashboard-client/did-hydrator": "1.0.0",
-    "@ev-dashboard-client/key-manager": "1.0.0",
-    "@ev-dashboard-client/prequalification-client": "1.0.0",
+    "@energyweb/ev-registry": "1.0.0",
+    "@energyweb/ev-did-hydrator": "1.0.0",
+    "@energyweb/ev-key-manager": "1.0.0",
+    "@energyweb/ev-prequalification": "1.0.0",
     "@ew-did-registry/keys": "0.0.1-alpha.694.1",
     "express": "~4.17.1",
     "body-parser": "~1.19.0",

--- a/apps/asset-operator-server/package.json
+++ b/apps/asset-operator-server/package.json
@@ -27,5 +27,9 @@
     "typescript": "~4.2.3",
     "rimraf": "~3.0.2",
     "@types/convict": "~6.0.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/apps/asset-operator-server/src/expressServer.ts
+++ b/apps/asset-operator-server/src/expressServer.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
-import { EvRegistry } from '@ev-dashboard-client/asset-registrar';
-import { DID } from '@ev-dashboard-client/did-hydrator';
+import { EvRegistry } from '@energyweb/ev-registry';
+import { DID } from '@energyweb/ev-did-hydrator';
 import { Keys } from '@ew-did-registry/keys';
 import { config } from './config';
 import { keyManager } from './keyManager';

--- a/apps/asset-operator-server/src/keyManager.ts
+++ b/apps/asset-operator-server/src/keyManager.ts
@@ -1,2 +1,2 @@
-import { KeyManager } from '@ev-dashboard-client/key-manager';
+import { KeyManager } from '@energyweb/ev-key-manager';
 export const keyManager: KeyManager = new KeyManager('keymanager.db');

--- a/apps/asset-operator-server/src/prequalificationClient.ts
+++ b/apps/asset-operator-server/src/prequalificationClient.ts
@@ -1,7 +1,4 @@
-import {
-  PrequalificationClient,
-  IamClientLibFactoryParams
-} from '@ev-dashboard-client/prequalification-client';
+import { PrequalificationClient, IamClientLibFactoryParams } from '@energyweb/ev-prequalification';
 import { config } from './config';
 import { keyManager } from './keyManager';
 

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -10,6 +10,15 @@
    * "rush my-global-command --help".
    */
   "commands": [
+        {
+          "commandKind": "bulk",
+          "name": "test",
+          "summary": "Run all test in packages",
+          "safeForSimultaneousRushProcesses": false,
+          "enableParallelism": false,
+          "ignoreMissingScript": true,
+          "allowWarningsInSuccessfulBuild": true
+        },
     // {
     //   /**
     //    * (Required) Determines the type of custom command.

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -757,7 +757,7 @@ packages:
   /@ew-did-registry/did-ethr-resolver/0.0.1-alpha.694.1:
     dependencies:
       '@ew-did-registry/did': 0.0.1-alpha.694.1
-      '@ew-did-registry/did-resolver-interface': 0.0.1-alpha.694.1
+      '@ew-did-registry/did-resolver-interface': 0.0.1-alpha.827.0
       '@ew-did-registry/keys': 0.0.1-alpha.694.1
       '@ew-did-registry/proxyidentity': 0.0.1-alpha.890.0
     dev: false
@@ -822,7 +822,7 @@ packages:
       '@ew-did-registry/keys': 0.0.1-alpha.632.0
       '@types/promise.allsettled': 1.0.3
       base64url: 3.0.1
-      ethereumjs-util: 7.0.9
+      ethereumjs-util: 7.0.10
       jsonwebtoken: 8.5.1
       key-encoder: 2.0.3
       promise.allsettled: 1.0.4
@@ -1633,7 +1633,7 @@ packages:
       integrity: sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==
   /accepts/1.3.7:
     dependencies:
-      mime-types: 2.1.29
+      mime-types: 2.1.30
       negotiator: 0.6.2
     dev: false
     engines:
@@ -2275,7 +2275,7 @@ packages:
     dependencies:
       caniuse-lite: 1.0.30001205
       colorette: 1.2.2
-      electron-to-chromium: 1.3.704
+      electron-to-chromium: 1.3.705
       escalade: 3.1.1
       node-releases: 1.1.71
     dev: false
@@ -3125,10 +3125,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.704:
+  /electron-to-chromium/1.3.705:
     dev: false
     resolution:
-      integrity: sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA==
+      integrity: sha512-agtrL5vLSOIK89sE/YSzAgqCw76eZ60gf3J7Tid5RfLbSp5H4nWL28/dIV+H+ZhNNi1JNiaF62jffwYsAyXc0g==
   /elliptic/6.3.3:
     dependencies:
       bn.js: 4.12.0
@@ -3756,7 +3756,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
-  /ethereumjs-util/7.0.9:
+  /ethereumjs-util/7.0.10:
     dependencies:
       '@types/bn.js': 5.1.0
       bn.js: 5.2.0
@@ -3768,7 +3768,7 @@ packages:
     engines:
       node: '>=10.0.0'
     resolution:
-      integrity: sha512-cRqvYYKJoitq6vMKMf8pXeVwvTrX+dRD0JwHaYqm8jvogK14tqIoCWH/KUHcRwnVxVXEYF/o6pup5jRG4V0xzg==
+      integrity: sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
   /ethereumjs-vm/2.6.0:
     dependencies:
       async: 2.6.3
@@ -4203,7 +4203,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.29
+      mime-types: 2.1.30
     dev: false
     engines:
       node: '>= 0.12'
@@ -4213,7 +4213,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.29
+      mime-types: 2.1.30
     dev: false
     engines:
       node: '>= 6'
@@ -6480,20 +6480,20 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
-  /mime-db/1.46.0:
+  /mime-db/1.47.0:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
-  /mime-types/2.1.29:
+      integrity: sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
+  /mime-types/2.1.30:
     dependencies:
-      mime-db: 1.46.0
+      mime-db: 1.47.0
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
+      integrity: sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   /mime/1.6.0:
     dev: false
     engines:
@@ -7738,7 +7738,7 @@ packages:
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
-      mime-types: 2.1.29
+      mime-types: 2.1.30
       oauth-sign: 0.9.0
       performance-now: 2.1.0
       qs: 6.5.2
@@ -8545,7 +8545,7 @@ packages:
       eth-lib: 0.1.29
       fs-extra: 4.0.3
       got: 7.1.0
-      mime-types: 2.1.29
+      mime-types: 2.1.30
       mkdirp-promise: 5.0.1
       mock-fs: 4.13.0
       setimmediate: 1.0.5
@@ -8897,7 +8897,7 @@ packages:
   /type-is/1.6.18:
     dependencies:
       media-typer: 0.3.0
-      mime-types: 2.1.29
+      mime-types: 2.1.30
     dev: false
     engines:
       node: '>= 0.6'

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -31,6 +31,7 @@ dependencies:
   eslint: 7.22.0
   ethers: 4.0.48
   express: 4.17.1
+  ganache-cli: 6.12.2
   iam-client-lib: 2.0.0-alpha.3
   jest: 26.6.3_ts-node@9.1.1
   nats: 1.4.12
@@ -9902,6 +9903,7 @@ packages:
       '@types/jest': 26.0.22
       eslint: 7.22.0
       ethers: 4.0.48
+      ganache-cli: 6.12.2
       jest: 26.6.3_ts-node@9.1.1
       rimraf: 3.0.2
       run-with-testrpc: 0.3.1
@@ -9915,7 +9917,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-EPXN/rBfrjd85gJnzuNFtwTz9zPbDRpMXgwHZzy599Yx/BBjt5Pzge9Ea2mg6UHGgI7c0OMiJSXVsb9qL50/7w==
+      integrity: sha512-e8xiWEHoZLYP9MMwUBNxrNQZpQFj+tYIB/CWVCROKRdGeUpWU5ualcsOQ075K9D9R6UE4o9h8+cjm7zbI9CnMg==
       tarball: file:projects/asset-registrar.tgz
     version: 0.0.0
   file:projects/contract-deployer.tgz:
@@ -10035,6 +10037,7 @@ specifiers:
   eslint: ~7.22.0
   ethers: ^4.0.48
   express: ~4.17.1
+  ganache-cli: ^6.4.2
   iam-client-lib: 2.0.0-alpha.3
   jest: ~26.6.3
   nats: ^1.4.12

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 dependencies:
-  '@ethersproject/bytes': 5.0.11
-  '@ethersproject/contracts': 5.0.12
-  '@ethersproject/providers': 5.0.24
-  '@ethersproject/wallet': 5.0.12
+  '@ethersproject/bytes': 5.1.0
+  '@ethersproject/contracts': 5.1.0
+  '@ethersproject/providers': 5.1.0
+  '@ethersproject/wallet': 5.1.0
   '@ew-did-registry/did': 0.0.1-alpha.694.1
   '@ew-did-registry/did-document': 0.0.1-alpha.694.1
   '@ew-did-registry/did-ethr-resolver': 0.0.1-alpha.694.1
@@ -22,9 +22,9 @@ dependencies:
   '@types/convict': 6.0.1
   '@types/events': 3.0.0
   '@types/express': 4.17.11
-  '@types/jest': 26.0.21
-  '@types/node': 14.14.35
-  '@types/yargs': 16.0.0
+  '@types/jest': 26.0.22
+  '@types/node': 14.14.37
+  '@types/yargs': 16.0.1
   better-sqlite3: 5.4.3
   body-parser: 1.19.0
   convict: 6.0.1
@@ -34,6 +34,7 @@ dependencies:
   iam-client-lib: 2.0.0-alpha.3
   jest: 26.6.3_ts-node@9.1.1
   nats: 1.4.12
+  pnpm: 5.18.5
   rimraf: 3.0.2
   run-with-testrpc: 0.3.1
   ts-jest: 26.5.4_jest@26.6.3+typescript@4.2.3
@@ -60,38 +61,37 @@ packages:
     dev: false
     resolution:
       integrity: sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==
-  /@babel/core/7.13.10:
+  /@babel/core/7.13.14:
     dependencies:
       '@babel/code-frame': 7.12.13
       '@babel/generator': 7.13.9
-      '@babel/helper-compilation-targets': 7.13.10_@babel+core@7.13.10
-      '@babel/helper-module-transforms': 7.13.12
+      '@babel/helper-compilation-targets': 7.13.13_@babel+core@7.13.14
+      '@babel/helper-module-transforms': 7.13.14
       '@babel/helpers': 7.13.10
-      '@babel/parser': 7.13.12
+      '@babel/parser': 7.13.13
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.12
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
       convert-source-map: 1.7.0
       debug: 4.3.1
       gensync: 1.0.0-beta.2
       json5: 2.2.0
-      lodash: 4.17.21
       semver: 6.3.0
       source-map: 0.5.7
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
+      integrity: sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==
   /@babel/generator/7.13.9:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: false
     resolution:
       integrity: sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
-  /@babel/helper-compilation-targets/7.13.10:
+  /@babel/helper-compilation-targets/7.13.13:
     dependencies:
       '@babel/compat-data': 7.13.12
       '@babel/helper-validator-option': 7.12.17
@@ -101,11 +101,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
-  /@babel/helper-compilation-targets/7.13.10_@babel+core@7.13.10:
+      integrity: sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
+  /@babel/helper-compilation-targets/7.13.13_@babel+core@7.13.14:
     dependencies:
       '@babel/compat-data': 7.13.12
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-validator-option': 7.12.17
       browserslist: 4.16.3
       semver: 6.3.0
@@ -113,13 +113,13 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
+      integrity: sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
   /@babel/helper-define-polyfill-provider/0.1.5:
     dependencies:
-      '@babel/helper-compilation-targets': 7.13.10
+      '@babel/helper-compilation-targets': 7.13.13
       '@babel/helper-module-imports': 7.13.12
       '@babel/helper-plugin-utils': 7.13.0
-      '@babel/traverse': 7.13.0
+      '@babel/traverse': 7.13.13
       debug: 4.3.1
       lodash.debounce: 4.0.8
       resolve: 1.20.0
@@ -133,29 +133,29 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.12.13
       '@babel/template': 7.12.13
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
   /@babel/helper-get-function-arity/7.12.13:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   /@babel/helper-member-expression-to-functions/7.13.12:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
   /@babel/helper-module-imports/7.13.12:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
-  /@babel/helper-module-transforms/7.13.12:
+  /@babel/helper-module-transforms/7.13.14:
     dependencies:
       '@babel/helper-module-imports': 7.13.12
       '@babel/helper-replace-supers': 7.13.12
@@ -163,14 +163,14 @@ packages:
       '@babel/helper-split-export-declaration': 7.12.13
       '@babel/helper-validator-identifier': 7.12.11
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.12
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
     dev: false
     resolution:
-      integrity: sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==
+      integrity: sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==
   /@babel/helper-optimise-call-expression/7.12.13:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
@@ -182,20 +182,20 @@ packages:
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.13.12
       '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.12
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
   /@babel/helper-simple-access/7.13.12:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   /@babel/helper-split-export-declaration/7.12.13:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
@@ -210,8 +210,8 @@ packages:
   /@babel/helpers/7.13.10:
     dependencies:
       '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.12
+      '@babel/traverse': 7.13.13
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
@@ -223,115 +223,115 @@ packages:
     dev: false
     resolution:
       integrity: sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
-  /@babel/parser/7.13.12:
+  /@babel/parser/7.13.13:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.13.10:
+      integrity: sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.13.10:
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.13.10:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.13.10:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.13.10:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-top-level-await/7.12.13_@babel+core@7.13.10:
+  /@babel/plugin-syntax-top-level-await/7.12.13_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@babel/helper-plugin-utils': 7.13.0
     dev: false
     peerDependencies:
@@ -360,40 +360,39 @@ packages:
   /@babel/template/7.12.13:
     dependencies:
       '@babel/code-frame': 7.12.13
-      '@babel/parser': 7.13.12
-      '@babel/types': 7.13.12
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
-  /@babel/traverse/7.13.0:
+  /@babel/traverse/7.13.13:
     dependencies:
       '@babel/code-frame': 7.12.13
       '@babel/generator': 7.13.9
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.13.12
-      '@babel/types': 7.13.12
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
       debug: 4.3.1
       globals: 11.12.0
-      lodash: 4.17.21
     dev: false
     resolution:
-      integrity: sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
-  /@babel/types/7.13.12:
+      integrity: sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==
+  /@babel/types/7.13.14:
     dependencies:
       '@babel/helper-validator-identifier': 7.12.11
       lodash: 4.17.21
       to-fast-properties: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==
+      integrity: sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
   /@bcoe/v8-coverage/0.2.3:
     dev: false
     resolution:
       integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
   /@cnakazawa/watch/1.0.4:
     dependencies:
-      exec-sh: 0.3.5
+      exec-sh: 0.3.6
       minimist: 1.2.5
     dev: false
     engines:
@@ -431,294 +430,296 @@ packages:
       node: ^10.12.0 || >=12.0.0
     resolution:
       integrity: sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
-  /@ethersproject/abi/5.0.13:
+  /@ethersproject/abi/5.1.0:
     dependencies:
-      '@ethersproject/address': 5.0.11
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/constants': 5.0.10
-      '@ethersproject/hash': 5.0.12
-      '@ethersproject/keccak256': 5.0.9
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/strings': 5.0.10
+      '@ethersproject/address': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/constants': 5.1.0
+      '@ethersproject/hash': 5.1.0
+      '@ethersproject/keccak256': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/strings': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-2coOH3D7ra1lwamKEH0HVc+Jbcsw5yfeCgmY8ekhCDualEiyyovD2qDcMBBcY3+kjoLHVTmo7ost6MNClxdOrg==
-  /@ethersproject/abstract-provider/5.0.10:
+      integrity: sha512-N/W9Sbn1/C6Kh2kuHRjf/hX6euMK4+9zdJRBB8sDWmihVntjUAfxbusGZKzDQD8i3szAHhTz8K7XADV5iFNfJw==
+  /@ethersproject/abstract-provider/5.1.0:
     dependencies:
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/networks': 5.0.9
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/transactions': 5.0.11
-      '@ethersproject/web': 5.0.14
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/networks': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/transactions': 5.1.0
+      '@ethersproject/web': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-OSReY5iz94iIaPlRvLiJP8YVIvQLx4aUvMMnHWSaA/vTU8QHZmgNlt4OBdYV1+aFY8Xl+VRYiWBHq72ZDKXXCQ==
-  /@ethersproject/abstract-signer/5.0.14:
+      integrity: sha512-8dJUnT8VNvPwWhYIau4dwp7qe1g+KgdRm4XTWvjkI9gAT2zZa90WF5ApdZ3vl1r6NDmnn6vUVvyphClRZRteTQ==
+  /@ethersproject/abstract-signer/5.1.0:
     dependencies:
-      '@ethersproject/abstract-provider': 5.0.10
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
+      '@ethersproject/abstract-provider': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-JztBwVO7o5OHLh2vyjordlS4/1EjRyaECtc8vPdXTF1i4dXN+J0coeRoPN6ZFbBvi/YbaB6br2fvqhst1VQD/g==
-  /@ethersproject/address/5.0.11:
+      integrity: sha512-qQDMkjGZSSJSKl6AnfTgmz9FSnzq3iEoEbHTYwjDlEAv+LNP7zd4ixCcVWlWyk+2siud856M5CRhAmPdupeN9w==
+  /@ethersproject/address/5.1.0:
     dependencies:
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/keccak256': 5.0.9
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/rlp': 5.0.9
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/keccak256': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/rlp': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==
-  /@ethersproject/base64/5.0.9:
+      integrity: sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==
+  /@ethersproject/base64/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
+      '@ethersproject/bytes': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-37RBz5LEZ9SlTNGiWCYFttnIN9J7qVs9Xo2EbqGqDH5LfW9EIji66S+YDMpXVo1zWDax1FkEldAoatxHK2gfgA==
-  /@ethersproject/basex/5.0.9:
+      integrity: sha512-npD1bLvK4Bcxz+m4EMkx+F8Rd7CnqS9DYnhNu0/GlQBXhWjvfoAZzk5HJ0f1qeyp8d+A86PTuzLOGOXf4/CN8g==
+  /@ethersproject/basex/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/properties': 5.0.9
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/properties': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-FANswl1IN3PS0eltQxH2aM2+utPrkLUVG4XVFi6SafRG9EpAqXCgycxC8PU90mPGhigYTpg9cnTB5mCZ6ejQjw==
-  /@ethersproject/bignumber/5.0.15:
+      integrity: sha512-vBKr39bum7DDbOvkr1Sj19bRMEPA4FnST6Utt6xhDzI7o7L6QNkDn2yrCfP+hnvJGhZFKtLygWwqlTBZoBXYLg==
+  /@ethersproject/bignumber/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
       bn.js: 4.12.0
     dev: false
     resolution:
-      integrity: sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==
-  /@ethersproject/bytes/5.0.11:
+      integrity: sha512-wUvQlhTjPjFXIdLPOuTrFeQmSa6Wvls1bGXQNQWvB/SEn1NsTCE8PmumIEZxmOPjSHl1eV2uyHP5jBm5Cgj92Q==
+  /@ethersproject/bytes/5.1.0:
     dependencies:
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/logger': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-D51plLYY5qF05AsoVQwIZVLqlBkaTPVHVP/1WmmBIWyHB0cRW0C9kh0kx5Exo51rB63Hk8PfHxc7SmpoaQFEyg==
-  /@ethersproject/constants/5.0.10:
+      integrity: sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==
+  /@ethersproject/constants/5.1.0:
     dependencies:
-      '@ethersproject/bignumber': 5.0.15
+      '@ethersproject/bignumber': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-OSo8jxkHLDXieCy8bgOFR7lMfgPxEzKvSDdP+WAWHCDM8+orwch0B6wzkTmiQFgryAtIctrBt5glAdJikZ3hGw==
-  /@ethersproject/contracts/5.0.12:
+      integrity: sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==
+  /@ethersproject/contracts/5.1.0:
     dependencies:
-      '@ethersproject/abi': 5.0.13
-      '@ethersproject/abstract-provider': 5.0.10
-      '@ethersproject/abstract-signer': 5.0.14
-      '@ethersproject/address': 5.0.11
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/constants': 5.0.10
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
+      '@ethersproject/abi': 5.1.0
+      '@ethersproject/abstract-provider': 5.1.0
+      '@ethersproject/abstract-signer': 5.1.0
+      '@ethersproject/address': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/constants': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/transactions': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-srijy31idjz8bE+gL1I6IRj2H4I9dUwfQ+QroLrIgNdGArqY8y2iFUKa3QTy+JBX26fJsdYiCQi1kKkaNpnMpQ==
-  /@ethersproject/hash/5.0.12:
+      integrity: sha512-dvTMs/4XGSc57cYOW0KjgX1NdTujUu7mNb6PQdJWg08m9ULzPyGZuBkFJnijBcp6vTOCQ59RwjboWgNWw393og==
+  /@ethersproject/hash/5.1.0:
     dependencies:
-      '@ethersproject/abstract-signer': 5.0.14
-      '@ethersproject/address': 5.0.11
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/keccak256': 5.0.9
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/strings': 5.0.10
+      '@ethersproject/abstract-signer': 5.1.0
+      '@ethersproject/address': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/keccak256': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/strings': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-kn4QN+fhNFbUgX3XZTZUaQixi0oyfIEY+hfW+KtkHu+rq7dV76oAIvaLEEynu1/4npOL38E4X4YI42gGZk+C0Q==
-  /@ethersproject/hdnode/5.0.10:
+      integrity: sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==
+  /@ethersproject/hdnode/5.1.0:
     dependencies:
-      '@ethersproject/abstract-signer': 5.0.14
-      '@ethersproject/basex': 5.0.9
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/pbkdf2': 5.0.9
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/sha2': 5.0.9
-      '@ethersproject/signing-key': 5.0.11
-      '@ethersproject/strings': 5.0.10
-      '@ethersproject/transactions': 5.0.11
-      '@ethersproject/wordlists': 5.0.10
+      '@ethersproject/abstract-signer': 5.1.0
+      '@ethersproject/basex': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/pbkdf2': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/sha2': 5.1.0
+      '@ethersproject/signing-key': 5.1.0
+      '@ethersproject/strings': 5.1.0
+      '@ethersproject/transactions': 5.1.0
+      '@ethersproject/wordlists': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==
-  /@ethersproject/json-wallets/5.0.12:
+      integrity: sha512-obIWdlujloExPHWJGmhJO/sETOOo7SEb6qemV4f8kyFoXg+cJK+Ta9SvBrj7hsUK85n3LZeZJZRjjM7oez3Clg==
+  /@ethersproject/json-wallets/5.1.0:
     dependencies:
-      '@ethersproject/abstract-signer': 5.0.14
-      '@ethersproject/address': 5.0.11
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/hdnode': 5.0.10
-      '@ethersproject/keccak256': 5.0.9
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/pbkdf2': 5.0.9
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/random': 5.0.9
-      '@ethersproject/strings': 5.0.10
-      '@ethersproject/transactions': 5.0.11
+      '@ethersproject/abstract-signer': 5.1.0
+      '@ethersproject/address': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/hdnode': 5.1.0
+      '@ethersproject/keccak256': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/pbkdf2': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/random': 5.1.0
+      '@ethersproject/strings': 5.1.0
+      '@ethersproject/transactions': 5.1.0
       aes-js: 3.0.0
       scrypt-js: 3.0.1
     dev: false
     resolution:
-      integrity: sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==
-  /@ethersproject/keccak256/5.0.9:
+      integrity: sha512-00n2iBy27w8zrGZSiU762UOVuzCQZxUZxopsZC47++js6xUFuI74DHcJ5K/2pddlF1YBskvmMuboEu1geK8mnA==
+  /@ethersproject/keccak256/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
+      '@ethersproject/bytes': 5.1.0
       js-sha3: 0.5.7
     dev: false
     resolution:
-      integrity: sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==
-  /@ethersproject/logger/5.0.10:
+      integrity: sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==
+  /@ethersproject/logger/5.1.0:
     dev: false
     resolution:
-      integrity: sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw==
-  /@ethersproject/networks/5.0.9:
+      integrity: sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw==
+  /@ethersproject/networks/5.1.0:
     dependencies:
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/logger': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-L8+VCQwArBLGkxZb/5Ns/OH/OxP38AcaveXIxhUTq+VWpXYjrObG3E7RDQIKkUx1S1IcQl/UWTz5w4DK0UitJg==
-  /@ethersproject/pbkdf2/5.0.9:
+      integrity: sha512-A/NIrIED/G/IgU1XUukOA3WcFRxn2I4O5GxsYGA5nFlIi+UZWdGojs85I1VXkR1gX9eFnDXzjE6OtbgZHjFhIA==
+  /@ethersproject/pbkdf2/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/sha2': 5.0.9
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/sha2': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==
-  /@ethersproject/properties/5.0.9:
+      integrity: sha512-B8cUbHHTgs8OtgJIafrRcz/YPDobVd5Ru8gTnShOiM9EBuFpYHQpq3+8iQJ6pyczDu6HP/oc/njAsIBhwFZYew==
+  /@ethersproject/properties/5.1.0:
     dependencies:
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/logger': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==
-  /@ethersproject/providers/5.0.24:
+      integrity: sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==
+  /@ethersproject/providers/5.1.0:
     dependencies:
-      '@ethersproject/abstract-provider': 5.0.10
-      '@ethersproject/abstract-signer': 5.0.14
-      '@ethersproject/address': 5.0.11
-      '@ethersproject/basex': 5.0.9
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/constants': 5.0.10
-      '@ethersproject/hash': 5.0.12
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/networks': 5.0.9
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/random': 5.0.9
-      '@ethersproject/rlp': 5.0.9
-      '@ethersproject/sha2': 5.0.9
-      '@ethersproject/strings': 5.0.10
-      '@ethersproject/transactions': 5.0.11
-      '@ethersproject/web': 5.0.14
+      '@ethersproject/abstract-provider': 5.1.0
+      '@ethersproject/abstract-signer': 5.1.0
+      '@ethersproject/address': 5.1.0
+      '@ethersproject/basex': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/constants': 5.1.0
+      '@ethersproject/hash': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/networks': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/random': 5.1.0
+      '@ethersproject/rlp': 5.1.0
+      '@ethersproject/sha2': 5.1.0
+      '@ethersproject/strings': 5.1.0
+      '@ethersproject/transactions': 5.1.0
+      '@ethersproject/web': 5.1.0
       bech32: 1.1.4
       ws: 7.2.3
     dev: false
     resolution:
-      integrity: sha512-M4Iw1r4gGJkt7ZUa++iREuviKL/DIpmIMsaUlVlXtV+ZrUXeN8xQ3zOTrbz7R4h9W9oljBZM7i4D3Kn1krJ30A==
-  /@ethersproject/random/5.0.9:
+      integrity: sha512-FjpZL2lSXrYpQDg2fMjugZ0HjQD9a+2fOOoRhhihh+Z+qi/xZ8vIlPoumrEP1DzIG4DBV6liUqLNqnX2C6FIAA==
+  /@ethersproject/random/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-DANG8THsKqFbJOantrxumtG6gyETNE54VfbsWa+SQAT8WKpDo9W/X5Zhh73KuhClaey1UI32uVmISZeq/Zxn1A==
-  /@ethersproject/rlp/5.0.9:
+      integrity: sha512-+uuczLQZ4+no9cP6TCoCktXx0u2YbNaRT7lRkSt12d8263e702f0u+4JnnRO8Qmv5nylWJebnqCHzyxP+6mLqw==
+  /@ethersproject/rlp/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==
-  /@ethersproject/sha2/5.0.9:
+      integrity: sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==
+  /@ethersproject/sha2/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
       hash.js: 1.1.3
     dev: false
     resolution:
-      integrity: sha512-5FH4s47gM7N1fFAYQ1+m7aX0SbLg0Xr+6tvqndmNqc382/qBIbzXiGlUookrsjlPb6gLNurnTssCXjNM72J6lQ==
-  /@ethersproject/signing-key/5.0.11:
+      integrity: sha512-+fNSeZRstOpdRJpdGUkRONFCaiAqWkc91zXgg76Nlp5ndBQE25Kk5yK8gCPG1aGnCrbariiPr5j9DmrYH78JCA==
+  /@ethersproject/signing-key/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      bn.js: 4.12.0
       elliptic: 6.5.4
     dev: false
     resolution:
-      integrity: sha512-Jfcru/BGwdkXhLxT+8WCZtFy7LL0TPFZw05FAb5asxB/MyVsEfNdNxGDtjVE9zXfmRSPe/EusXYY4K7wcygOyQ==
-  /@ethersproject/strings/5.0.10:
+      integrity: sha512-tE5LFlbmdObG8bY04NpuwPWSRPgEswfxweAI1sH7TbP0ml1elNfqcq7ii/3AvIN05i5U0Pkm3Tf8bramt8MmLw==
+  /@ethersproject/strings/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/constants': 5.0.10
-      '@ethersproject/logger': 5.0.10
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/constants': 5.1.0
+      '@ethersproject/logger': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-KAeoS1tZ9/5ECXiIZA6S6hywbD0so2VmuW+Wfyo5EDXeyZ6Na1nxTPhTnW7voQmjbeYJffCrOc0qLFJeylyg7w==
-  /@ethersproject/transactions/5.0.11:
+      integrity: sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==
+  /@ethersproject/transactions/5.1.0:
     dependencies:
-      '@ethersproject/address': 5.0.11
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/constants': 5.0.10
-      '@ethersproject/keccak256': 5.0.9
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/rlp': 5.0.9
-      '@ethersproject/signing-key': 5.0.11
+      '@ethersproject/address': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/constants': 5.1.0
+      '@ethersproject/keccak256': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/rlp': 5.1.0
+      '@ethersproject/signing-key': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-ftsRvR9+gQp7L63F6+XmstvsZ4w8GtWvQB08e/zB+oB86Fnhq8+i/tkgpJplSHC8I/qgiCisva+M3u2GVhDFPA==
-  /@ethersproject/wallet/5.0.12:
+      integrity: sha512-s10crRLZEA0Bgv6FGEl/AKkTw9f+RVUrlWDX1rHnD4ZncPFeiV2AJr4nT7QSUhxJdFPvjyKRDb3nEH27dIqcPQ==
+  /@ethersproject/wallet/5.1.0:
     dependencies:
-      '@ethersproject/abstract-provider': 5.0.10
-      '@ethersproject/abstract-signer': 5.0.14
-      '@ethersproject/address': 5.0.11
-      '@ethersproject/bignumber': 5.0.15
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/hash': 5.0.12
-      '@ethersproject/hdnode': 5.0.10
-      '@ethersproject/json-wallets': 5.0.12
-      '@ethersproject/keccak256': 5.0.9
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/random': 5.0.9
-      '@ethersproject/signing-key': 5.0.11
-      '@ethersproject/transactions': 5.0.11
-      '@ethersproject/wordlists': 5.0.10
+      '@ethersproject/abstract-provider': 5.1.0
+      '@ethersproject/abstract-signer': 5.1.0
+      '@ethersproject/address': 5.1.0
+      '@ethersproject/bignumber': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/hash': 5.1.0
+      '@ethersproject/hdnode': 5.1.0
+      '@ethersproject/json-wallets': 5.1.0
+      '@ethersproject/keccak256': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/random': 5.1.0
+      '@ethersproject/signing-key': 5.1.0
+      '@ethersproject/transactions': 5.1.0
+      '@ethersproject/wordlists': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==
-  /@ethersproject/web/5.0.14:
+      integrity: sha512-ULmUtiYQLTUS+y3DgkLzRhFEK10zMwmjOthnjiZxee3Q/MVwr3rnmuAnXIUZrPjna6hvUPnyRIdW5XuF0Ld0YQ==
+  /@ethersproject/web/5.1.0:
     dependencies:
-      '@ethersproject/base64': 5.0.9
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/strings': 5.0.10
+      '@ethersproject/base64': 5.1.0
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/strings': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-QpTgplslwZ0Sp9oKNLoRuS6TKxnkwfaEk3gr7zd7XLF8XBsYejsrQO/03fNfnMx/TAT/RR6WEw/mbOwpRSeVRA==
-  /@ethersproject/wordlists/5.0.10:
+      integrity: sha512-LTeluWgTq04+RNqAkVhpydPcRZK/kKxD2Vy7PYGrAD27ABO9kTqTBKwiOuzTyAHKUQHfnvZbXmxBXJAGViSDcA==
+  /@ethersproject/wordlists/5.1.0:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/hash': 5.0.12
-      '@ethersproject/logger': 5.0.10
-      '@ethersproject/properties': 5.0.9
-      '@ethersproject/strings': 5.0.10
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/hash': 5.1.0
+      '@ethersproject/logger': 5.1.0
+      '@ethersproject/properties': 5.1.0
+      '@ethersproject/strings': 5.1.0
     dev: false
     resolution:
-      integrity: sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==
+      integrity: sha512-NsUCi/TpBb+oTFvMSccUkJGtp5o/84eOyqp5q5aBeiNBSLkYyw21znRn9mAmxZgySpxgruVgKbaapnYPgvctPQ==
   /@ew-did-registry/claims/0.0.1-alpha.827.0:
     dependencies:
       '@ew-did-registry/did': 0.0.1-alpha.632.0
@@ -767,7 +768,7 @@ packages:
       '@ew-did-registry/did-resolver-interface': 0.0.1-alpha.827.0
       '@ew-did-registry/keys': 0.0.1-alpha.632.0
       '@ew-did-registry/proxyidentity': 0.0.1-alpha.757.0
-      '@walletconnect/client': 1.4.0
+      '@walletconnect/client': 1.4.1
     dev: false
     resolution:
       integrity: sha512-vU+BnaPhRU1779JN1Zzz9k+XFeXWBAi/Qgys78PIjamOrfUkqmhuUxbmbg3HdtIChfZDqvSa9G0m86DIHcrDJA==
@@ -875,7 +876,7 @@ packages:
   /@jest/console/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       chalk: 4.1.0
       jest-message-util: 26.6.2
       jest-util: 26.6.2
@@ -892,8 +893,8 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
-      ansi-escapes: 4.3.1
+      '@types/node': 14.14.37
+      ansi-escapes: 4.3.2
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.6
@@ -926,7 +927,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       jest-mock: 26.6.2
     dev: false
     engines:
@@ -937,7 +938,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@sinonjs/fake-timers': 6.0.1
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       jest-message-util: 26.6.2
       jest-mock: 26.6.2
       jest-util: 26.6.2
@@ -981,7 +982,7 @@ packages:
       source-map: 0.6.1
       string-length: 4.0.2
       terminal-link: 2.1.1
-      v8-to-istanbul: 7.1.0
+      v8-to-istanbul: 7.1.1
     dev: false
     engines:
       node: '>= 10.14.2'
@@ -1026,7 +1027,7 @@ packages:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.6.2:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@jest/types': 26.6.2
       babel-plugin-istanbul: 6.0.0
       chalk: 4.1.0
@@ -1050,7 +1051,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.0
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       '@types/yargs': 15.0.13
       chalk: 4.1.0
     dev: false
@@ -1203,8 +1204,8 @@ packages:
       integrity: sha512-9lWTOMtnQJvR4eJ8tM14oeJXE5UGqRD0gqLiT4DNck5/OQwxTUs+W2v/Lah4bJzql0BxmxlEBueuLS4IGc3xGg==
   /@types/babel__core/7.1.14:
     dependencies:
-      '@babel/parser': 7.13.12
-      '@babel/types': 7.13.12
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
       '@types/babel__generator': 7.6.2
       '@types/babel__template': 7.4.0
       '@types/babel__traverse': 7.11.1
@@ -1213,51 +1214,51 @@ packages:
       integrity: sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
   /@types/babel__generator/7.6.2:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
   /@types/babel__template/7.4.0:
     dependencies:
-      '@babel/parser': 7.13.12
-      '@babel/types': 7.13.12
+      '@babel/parser': 7.13.13
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
   /@types/babel__traverse/7.11.1:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
     dev: false
     resolution:
       integrity: sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==
   /@types/bn.js/4.11.6:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
   /@types/bn.js/5.1.0:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
   /@types/body-parser/1.19.0:
     dependencies:
       '@types/connect': 3.4.34
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
   /@types/connect/3.4.34:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
   /@types/convict/6.0.1:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-5094Bw9nSvkUNV7qqUvzDt6lgWZpKbpR/AJu8lmtojKa12nxtHHGrPFwK3YP4YZA1rCc2tbpI5TUEBU35eqVxg==
@@ -1277,7 +1278,7 @@ packages:
       integrity: sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
   /@types/express-serve-static-core/4.17.19:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       '@types/qs': 6.9.6
       '@types/range-parser': 1.2.3
     dev: false
@@ -1294,7 +1295,7 @@ packages:
       integrity: sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
   /@types/graceful-fs/4.1.5:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
@@ -1314,13 +1315,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
-  /@types/jest/26.0.21:
+  /@types/jest/26.0.22:
     dependencies:
       jest-diff: 26.6.2
       pretty-format: 26.6.2
     dev: false
     resolution:
-      integrity: sha512-ab9TyM/69yg7eew9eOwKMUmvIZAKEGZYlq/dhe5/0IMUd/QLJv5ldRMdddSn+u22N13FP3s5jYyktxuBwY0kDA==
+      integrity: sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
   /@types/json-schema/7.0.7:
     dev: false
     resolution:
@@ -1331,29 +1332,29 @@ packages:
       integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
   /@types/mkdirp/0.5.2:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
-  /@types/node/10.17.55:
+  /@types/node/10.17.56:
     dev: false
     resolution:
-      integrity: sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg==
-  /@types/node/12.20.6:
+      integrity: sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w==
+  /@types/node/12.20.7:
     dev: false
     resolution:
-      integrity: sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==
-  /@types/node/14.14.35:
+      integrity: sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
+  /@types/node/14.14.37:
     dev: false
     resolution:
-      integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+      integrity: sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
   /@types/normalize-package-data/2.4.0:
     dev: false
     resolution:
       integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
   /@types/pbkdf2/3.1.0:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
@@ -1375,20 +1376,20 @@ packages:
       integrity: sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   /@types/secp256k1/4.0.1:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==
   /@types/serve-static/1.13.9:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     resolution:
       integrity: sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==
@@ -1406,12 +1407,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
-  /@types/yargs/16.0.0:
+  /@types/yargs/16.0.1:
     dependencies:
       '@types/yargs-parser': 20.2.0
     dev: false
     resolution:
-      integrity: sha512-2nN6AGeMwe8+O6nO9ytQfbMQOJy65oi1yK2y/9oReR08DaXSGtMsrLyCM1ooKqfICpCx4oITaR4LkOmdzz41Ww==
+      integrity: sha512-x4HABGLyzr5hKUzBC9dvjciOTm11WVH1NWonNjGgxapnTHu5SWUqyqn0zQ6Re0yQU0lsQ6ztLCoMAKDGZflyxA==
   /@typescript-eslint/eslint-plugin/3.4.0_8b99f3166f95e6f5099cfdeed4758787:
     dependencies:
       '@typescript-eslint/experimental-utils': 3.4.0_eslint@7.22.0+typescript@4.2.3
@@ -1489,94 +1490,95 @@ packages:
         optional: true
     resolution:
       integrity: sha512-zKwLiybtt4uJb4mkG5q2t6+W7BuYx2IISiDNV+IY68VfoGwErDx/RfVI7SWL4gnZ2t1A1ytQQwZ+YOJbHHJ2rw==
-  /@walletconnect/browser-utils/1.4.0:
+  /@walletconnect/browser-utils/1.4.1:
     dependencies:
-      '@walletconnect/types': 1.4.0
+      '@walletconnect/types': 1.4.1
       detect-browser: 5.2.0
       safe-json-utils: 1.0.0
       window-getters: 1.0.0
       window-metadata: 1.0.0
     dev: false
     resolution:
-      integrity: sha512-2oLQGaQ53bJvoToYG17XGf8palfbNF4ZdSvBKmEYX1ac9NnDetEPBfryz0Ij2s4f9o9XfVKFO7+HPLzm2ayMMw==
-  /@walletconnect/client/1.4.0:
+      integrity: sha512-ONrkPSI/27o1Wj8kUwE0uUZFk0GDCDQBJy614GsrhcwuQwJEW/B+nXPQ+Ca/4WvQySM5hWVHp1gO1kozSUkh3A==
+  /@walletconnect/client/1.4.1:
     dependencies:
-      '@walletconnect/core': 1.4.0
-      '@walletconnect/iso-crypto': 1.4.0
-      '@walletconnect/types': 1.4.0
-      '@walletconnect/utils': 1.4.0
+      '@walletconnect/core': 1.4.1
+      '@walletconnect/iso-crypto': 1.4.1
+      '@walletconnect/types': 1.4.1
+      '@walletconnect/utils': 1.4.1
     dev: false
     resolution:
-      integrity: sha512-lg3JFCuECCvZEl7BpOztNtnStOmOpGqXuSIhisnaEtqUgHdopH275Rz5jU736X5uS+7VExU6LOIWKNPPXlY2ZQ==
-  /@walletconnect/core/1.4.0:
+      integrity: sha512-JRW+9+j9LwszY76/WcIumEiLmhX7eidorH9SFFmI2pFfbrhB6KLe87FaA106kxwZUyWKOLZ6jVV4d1urYSdEwA==
+  /@walletconnect/core/1.4.1:
     dependencies:
-      '@walletconnect/socket-transport': 1.4.0
-      '@walletconnect/types': 1.4.0
-      '@walletconnect/utils': 1.4.0
+      '@walletconnect/socket-transport': 1.4.1
+      '@walletconnect/types': 1.4.1
+      '@walletconnect/utils': 1.4.1
     dev: false
     resolution:
-      integrity: sha512-0rPfgSAcdCHG/JcEUgLAJ6wnQOsd7AiBEAUv7d71ViORu1gKrXm8mWKpWnPkPV53IH+oRVVP0pAGEpwo7f+Bdw==
-  /@walletconnect/http-connection/1.4.0:
+      integrity: sha512-NzWvhk4akI2uhORUxMDMS/8yAdfp+nzvb5QdTE0eTD0WOrK16qAfYLSU/IjFc2J2lqhuPVxfO2XV7QoxgCXfwA==
+  /@walletconnect/http-connection/1.4.1:
     dependencies:
-      '@walletconnect/types': 1.4.0
-      '@walletconnect/utils': 1.4.0
+      '@walletconnect/types': 1.4.1
+      '@walletconnect/utils': 1.4.1
       eventemitter3: 4.0.7
       xhr2-cookies: 1.1.0
     dev: false
     resolution:
-      integrity: sha512-HIYrgzz/Fagwoyco6RsnxAD9pFLdt0cp+g+Rhw770QIhax0PjzpiC+IcLcYqVDFcCJwss6pZFlyPu7AAK67VDw==
-  /@walletconnect/iso-crypto/1.4.0:
+      integrity: sha512-nxpaTjS89exDQQdrp/NJsbbfREio6WQ0aJ9+nZv1YGIIGVu/7WaNDuVY+UXbaBWPEKYrysf4nvzNHJ2BWhkqoA==
+  /@walletconnect/iso-crypto/1.4.1:
     dependencies:
       '@pedrouid/iso-crypto': 1.1.0
-      '@walletconnect/types': 1.4.0
-      '@walletconnect/utils': 1.4.0
+      '@walletconnect/types': 1.4.1
+      '@walletconnect/utils': 1.4.1
     dev: false
     resolution:
-      integrity: sha512-pd5N6brECiRCp9A7skW1gL/fw24vjzy8zQJvn75GFRcuYcHNgpQwFOAq5OvaZt6/9wBIL1rVZ9QdBpyZ+EX85w==
+      integrity: sha512-rzfqM/DFhzNxBriMCU4DOarPkH+Brgll+2a2YeO6zHgMlwZtBKi5mMgzBwbDC3XygOvKbcRTB9G9hr8uYn+i5g==
   /@walletconnect/mobile-registry/1.4.0:
+    deprecated: 'Deprecated in favor of dynamic registry available from: https://github.com/walletconnect/walletconnect-registry'
     dev: false
     resolution:
       integrity: sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw==
-  /@walletconnect/qrcode-modal/1.4.0:
+  /@walletconnect/qrcode-modal/1.4.1:
     dependencies:
-      '@walletconnect/browser-utils': 1.4.0
+      '@walletconnect/browser-utils': 1.4.1
       '@walletconnect/mobile-registry': 1.4.0
-      '@walletconnect/types': 1.4.0
+      '@walletconnect/types': 1.4.1
       preact: 10.4.1
       qrcode: 1.4.4
     dev: false
     resolution:
-      integrity: sha512-FOov70va04sOReI9ijGPbYexXtNWS7VZPlSEv7vHLq5ufcghh0sPsl5MfO6wvyNqpSJERbGoTmaHLSMR7LjpFg==
-  /@walletconnect/socket-transport/1.4.0:
+      integrity: sha512-cIPKwYg+029UQY0natMyuNudxppYMfAzV2zAgdOSViphKTRY8RTI0DcJXVGPXEwx4k6Os3Vj6Fhqqo3RXOtgKg==
+  /@walletconnect/socket-transport/1.4.1:
     dependencies:
-      '@walletconnect/types': 1.4.0
-      '@walletconnect/utils': 1.4.0
+      '@walletconnect/types': 1.4.1
+      '@walletconnect/utils': 1.4.1
       ws: 7.3.0
     dev: false
     resolution:
-      integrity: sha512-X/7Hm+4w0d9fn0xf8adXetlHxmvpyw1cvUPHSCPxEzC+xACdZE1Q/dveDfEb/RaWlv7Z3IQoagVSCN/3xzkyYQ==
-  /@walletconnect/types/1.4.0:
+      integrity: sha512-/5Mhu4bu3tS52LqTlmmjx5x/N89XqbuT0YMobvQ+k/m+VqSeBDntqIjwBt7XiFlCbrUTq3/yTajavGFxWFB6pA==
+  /@walletconnect/types/1.4.1:
     dev: false
     resolution:
-      integrity: sha512-aCeuVzIos3VsRIK+/nnk8WHAftQNVOLUeWOTZoClOOGFJk5HpaPNfyIHJ+hjU4VXh/3YuN0yqnCeMWVjKlQ3nw==
-  /@walletconnect/utils/1.4.0:
+      integrity: sha512-lzS9NbXjVb5N+W/UnCZAflxjLtYepUi4ev1IeFozSvr/cWxAhEe/sjixe7WEIpYklW27kfBhKccMH/KjUoRC7w==
+  /@walletconnect/utils/1.4.1:
     dependencies:
       '@json-rpc-tools/utils': 1.6.1
-      '@walletconnect/browser-utils': 1.4.0
-      '@walletconnect/types': 1.4.0
+      '@walletconnect/browser-utils': 1.4.1
+      '@walletconnect/types': 1.4.1
       bn.js: 4.11.8
       enc-utils: 3.0.0
       js-sha3: 0.8.0
       query-string: 6.13.5
     dev: false
     resolution:
-      integrity: sha512-MFUKROV/TQKj6J95uNW0s04MU/yhl6wohZh5LwtKbFKIY2tsba+qM2miEXMo9fMOpxq/HnjBsVVVTZT9bSeIRw==
+      integrity: sha512-JrVjcXmWVcU02fmVNZFBpJ48f84qyar24CF7szGv+k9ZxvU9J7XkM+Fic4790Dt3DaWhOzS9/eBUa+BEZcBbNw==
   /@walletconnect/web3-provider/1.0.0-rc.4:
     dependencies:
-      '@walletconnect/client': 1.4.0
-      '@walletconnect/http-connection': 1.4.0
-      '@walletconnect/qrcode-modal': 1.4.0
-      '@walletconnect/types': 1.4.0
+      '@walletconnect/client': 1.4.1
+      '@walletconnect/http-connection': 1.4.1
+      '@walletconnect/qrcode-modal': 1.4.1
+      '@walletconnect/types': 1.4.1
       web3-provider-engine: 15.0.7
     dev: false
     resolution:
@@ -1689,7 +1691,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  /ajv/7.2.3:
+  /ajv/8.0.2:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -1697,21 +1699,21 @@ packages:
       uri-js: 4.4.1
     dev: false
     resolution:
-      integrity: sha512-idv5WZvKVXDqKralOImQgPM9v6WOdLNa0IY3B3doOjw/YxRGT8I+allIJ6kd7Uaj+SF1xZUSU+nPM5aDNBVtnw==
+      integrity: sha512-V0HGxJd0PiDF0ecHYIesTOqfd1gJguwQUOYfMfAWnRsWQEXfc5ifbUFhD3Wjc+O+y7VAqL+g07prq9gHQ/JOZQ==
   /ansi-colors/4.1.1:
     dev: false
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-  /ansi-escapes/4.3.1:
+  /ansi-escapes/4.3.2:
     dependencies:
-      type-fest: 0.11.0
+      type-fest: 0.21.3
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+      integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   /ansi-regex/2.1.1:
     dev: false
     engines:
@@ -1945,14 +1947,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  /babel-jest/26.6.3_@babel+core@7.13.10:
+  /babel-jest/26.6.3_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
       '@types/babel__core': 7.1.14
       babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 26.6.2_@babel+core@7.13.10
+      babel-preset-jest: 26.6.2_@babel+core@7.13.14
       chalk: 4.1.0
       graceful-fs: 4.2.6
       slash: 3.0.0
@@ -1978,7 +1980,7 @@ packages:
   /babel-plugin-jest-hoist/26.6.2:
     dependencies:
       '@babel/template': 7.12.13
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
       '@types/babel__core': 7.1.14
       '@types/babel__traverse': 7.11.1
     dev: false
@@ -1999,7 +2001,7 @@ packages:
   /babel-plugin-polyfill-corejs3/0.1.7:
     dependencies:
       '@babel/helper-define-polyfill-provider': 0.1.5
-      core-js-compat: 3.9.1
+      core-js-compat: 3.10.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2013,31 +2015,31 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==
-  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.13.10:
+  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.10
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.13.10
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.13.10
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.10
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.10
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.10
-      '@babel/plugin-syntax-top-level-await': 7.12.13_@babel+core@7.13.10
+      '@babel/core': 7.13.14
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.13.14
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.13.14
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.13.14
+      '@babel/plugin-syntax-top-level-await': 7.12.13_@babel+core@7.13.14
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
-  /babel-preset-jest/26.6.2_@babel+core@7.13.10:
+  /babel-preset-jest/26.6.2_@babel+core@7.13.14:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       babel-plugin-jest-hoist: 26.6.2
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.13.10
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.13.14
     dev: false
     engines:
       node: '>= 10.14.2'
@@ -2270,9 +2272,9 @@ packages:
       integrity: sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
   /browserslist/4.16.3:
     dependencies:
-      caniuse-lite: 1.0.30001204
+      caniuse-lite: 1.0.30001205
       colorette: 1.2.2
-      electron-to-chromium: 1.3.696
+      electron-to-chromium: 1.3.703
       escalade: 3.1.1
       node-releases: 1.1.71
     dev: false
@@ -2425,10 +2427,10 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
-  /caniuse-lite/1.0.30001204:
+  /caniuse-lite/1.0.30001205:
     dev: false
     resolution:
-      integrity: sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
+      integrity: sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==
   /capture-exit/2.0.0:
     dependencies:
       rsvp: 4.8.5
@@ -2712,13 +2714,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-  /core-js-compat/3.9.1:
+  /core-js-compat/3.10.0:
     dependencies:
       browserslist: 4.16.3
       semver: 7.0.0
     dev: false
     resolution:
-      integrity: sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==
+      integrity: sha512-9yVewub2MXNYyGvuLnMHcN1k9RkvB7/ofktpeKTIaASyB88YYqGzUnu0ywMMhJrDHOMiTjSHWGzR+i7Wb9Z1kQ==
   /core-util-is/1.0.2:
     dev: false
     resolution:
@@ -2844,7 +2846,7 @@ packages:
     dependencies:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
-      whatwg-url: 8.4.0
+      whatwg-url: 8.5.0
     dev: false
     engines:
       node: '>=10'
@@ -3122,10 +3124,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.696:
+  /electron-to-chromium/1.3.703:
     dev: false
     resolution:
-      integrity: sha512-yuKKvBuXe+IWRp6DxqbGUxbPtamh5C+mEC38vZ0KLxQFpGG9TQn0DbPL9WhWhQnfNhLyzxmPYlCzShbs8QxGbA==
+      integrity: sha512-SVBVhNB+4zPL+rvtWLw7PZQkw/Eqj1HQZs22xtcqW36+xoifzEOEEDEpkxSMfB6RFeSIOcG00w6z5mSqLr1Y6w==
   /elliptic/6.3.3:
     dependencies:
       bn.js: 4.12.0
@@ -3252,7 +3254,7 @@ packages:
       object.assign: 4.1.2
       string.prototype.trimend: 1.0.4
       string.prototype.trimstart: 1.0.4
-      unbox-primitive: 1.0.0
+      unbox-primitive: 1.0.1
     dev: false
     engines:
       node: '>= 0.4'
@@ -3443,7 +3445,7 @@ packages:
       semver: 7.3.5
       strip-ansi: 6.0.0
       strip-json-comments: 3.1.1
-      table: 6.0.7
+      table: 6.0.9
       text-table: 0.2.0
       v8-compile-cache: 2.3.0
     dev: false
@@ -3784,7 +3786,7 @@ packages:
       integrity: sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==
   /ethers/4.0.0-beta.3:
     dependencies:
-      '@types/node': 10.17.55
+      '@types/node': 10.17.56
       aes-js: 3.0.0
       bn.js: 4.12.0
       elliptic: 6.3.3
@@ -3872,10 +3874,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
-  /exec-sh/0.3.5:
+  /exec-sh/0.3.6:
     dev: false
     resolution:
-      integrity: sha512-0hzpaUazv4mEccxdn3TXC+HWNeVXNKMCJRK6E7Xyg+LwGAYI3yFag6jTkd4injV+kChYDQS1ftqDhnDVWNhU8A==
+      integrity: sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==
   /execa/1.0.0:
     dependencies:
       cross-spawn: 6.0.5
@@ -4621,7 +4623,7 @@ packages:
       integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   /hmac-drbg/1.0.1:
     dependencies:
-      hash.js: 1.1.7
+      hash.js: 1.1.3
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     dev: false
@@ -5324,7 +5326,7 @@ packages:
       integrity: sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -5464,10 +5466,10 @@ packages:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.6.3_ts-node@9.1.1:
     dependencies:
-      '@babel/core': 7.13.10
+      '@babel/core': 7.13.14
       '@jest/test-sequencer': 26.6.3_ts-node@9.1.1
       '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.13.10
+      babel-jest: 26.6.3_@babel+core@7.13.14
       chalk: 4.1.0
       deepmerge: 4.2.2
       glob: 7.1.6
@@ -5529,10 +5531,10 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       jest-mock: 26.6.2
       jest-util: 26.6.2
-      jsdom: 16.5.1
+      jsdom: 16.5.2
     dev: false
     engines:
       node: '>= 10.14.2'
@@ -5543,7 +5545,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       jest-mock: 26.6.2
       jest-util: 26.6.2
     dev: false
@@ -5561,7 +5563,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       anymatch: 3.1.1
       fb-watchman: 2.0.1
       graceful-fs: 4.2.6
@@ -5581,12 +5583,12 @@ packages:
       integrity: sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==
   /jest-jasmine2/26.6.3_ts-node@9.1.1:
     dependencies:
-      '@babel/traverse': 7.13.0
+      '@babel/traverse': 7.13.13
       '@jest/environment': 26.6.2
       '@jest/source-map': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       chalk: 4.1.0
       co: 4.6.0
       expect: 26.6.2
@@ -5645,7 +5647,7 @@ packages:
   /jest-mock/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: false
     engines:
       node: '>= 10.14.2'
@@ -5701,7 +5703,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       chalk: 4.1.0
       emittery: 0.7.2
       exit: 0.1.2
@@ -5763,7 +5765,7 @@ packages:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.6.2:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       graceful-fs: 4.2.6
     dev: false
     engines:
@@ -5772,7 +5774,7 @@ packages:
       integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==
   /jest-snapshot/26.6.2:
     dependencies:
-      '@babel/types': 7.13.12
+      '@babel/types': 7.13.14
       '@jest/types': 26.6.2
       '@types/babel__traverse': 7.11.1
       '@types/prettier': 2.2.3
@@ -5796,7 +5798,7 @@ packages:
   /jest-util/26.6.2:
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       chalk: 4.1.0
       graceful-fs: 4.2.6
       is-ci: 2.0.0
@@ -5823,8 +5825,8 @@ packages:
     dependencies:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 14.14.35
-      ansi-escapes: 4.3.1
+      '@types/node': 14.14.37
+      ansi-escapes: 4.3.2
       chalk: 4.1.0
       jest-util: 26.6.2
       string-length: 4.0.2
@@ -5835,7 +5837,7 @@ packages:
       integrity: sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==
   /jest-worker/26.6.2:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: false
@@ -5884,7 +5886,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
-  /jsdom/16.5.1:
+  /jsdom/16.5.2:
     dependencies:
       abab: 2.0.5
       acorn: 8.1.0
@@ -5909,7 +5911,7 @@ packages:
       webidl-conversions: 6.1.0
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
-      whatwg-url: 8.4.0
+      whatwg-url: 8.5.0
       ws: 7.4.4
       xml-name-validator: 3.0.0
     dev: false
@@ -5921,7 +5923,7 @@ packages:
       canvas:
         optional: true
     resolution:
-      integrity: sha512-pF73EOsJgwZekbDHEY5VO/yKXUkab/DuvrQB/ANVizbr6UAHJsDdHXuotZYwkJSGQl1JM+ivXaqY+XBDDL4TiA==
+      integrity: sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==
   /jsesc/2.5.2:
     dev: false
     engines:
@@ -6263,6 +6265,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+  /lodash.flatten/4.4.0:
+    dev: false
+    resolution:
+      integrity: sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
   /lodash.includes/4.3.0:
     dev: false
     resolution:
@@ -6291,10 +6297,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-  /lodash.sortby/4.7.0:
+  /lodash.truncate/4.4.2:
     dev: false
     resolution:
-      integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+      integrity: sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
   /lodash/4.17.21:
     dev: false
     resolution:
@@ -7304,6 +7310,13 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+  /pnpm/5.18.5:
+    dev: false
+    engines:
+      node: '>=10.16'
+    hasBin: true
+    resolution:
+      integrity: sha512-cTlgJ1VB41A8kDXohNJ/Ut08Mvj5hFNfjHSUx/Sz/xEvW0dvV7SVsAXY4wyak+AOBQdbvSmnqNUlKPT4wtMEvQ==
   /posix-character-classes/0.1.1:
     dev: false
     engines:
@@ -7895,7 +7908,7 @@ packages:
       '@cnakazawa/watch': 1.0.4
       anymatch: 2.0.0
       capture-exit: 2.0.0
-      exec-sh: 0.3.5
+      exec-sh: 0.3.6
       execa: 1.0.0
       fb-watchman: 2.0.1
       micromatch: 3.1.10
@@ -8544,17 +8557,22 @@ packages:
     dev: false
     resolution:
       integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-  /table/6.0.7:
+  /table/6.0.9:
     dependencies:
-      ajv: 7.2.3
-      lodash: 4.17.21
+      ajv: 8.0.2
+      is-boolean-object: 1.1.0
+      is-number-object: 1.0.4
+      is-string: 1.0.5
+      lodash.clonedeep: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.2
     dev: false
     engines:
       node: '>=10.0.0'
     resolution:
-      integrity: sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
+      integrity: sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==
   /tar-stream/1.6.2:
     dependencies:
       bl: 1.2.3
@@ -8585,7 +8603,7 @@ packages:
       integrity: sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
   /terminal-link/2.1.1:
     dependencies:
-      ansi-escapes: 4.3.1
+      ansi-escapes: 4.3.2
       supports-hyperlinks: 2.1.0
     dev: false
     engines:
@@ -8851,18 +8869,18 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-  /type-fest/0.11.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
   /type-fest/0.20.2:
     dev: false
     engines:
       node: '>=10'
     resolution:
       integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+  /type-fest/0.21.3:
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
   /type-fest/0.6.0:
     dev: false
     engines:
@@ -8928,7 +8946,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
-  /unbox-primitive/1.0.0:
+  /unbox-primitive/1.0.1:
     dependencies:
       function-bind: 1.1.1
       has-bigints: 1.0.1
@@ -8936,7 +8954,7 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: false
     resolution:
-      integrity: sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==
+      integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
   /unbzip2-stream/1.4.3:
     dependencies:
       buffer: 5.7.1
@@ -9072,7 +9090,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
-  /v8-to-istanbul/7.1.0:
+  /v8-to-istanbul/7.1.1:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 1.7.0
@@ -9081,7 +9099,7 @@ packages:
     engines:
       node: '>=10.10.0'
     resolution:
-      integrity: sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==
+      integrity: sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==
   /validate-npm-package-license/3.0.4:
     dependencies:
       spdx-correct: 3.1.1
@@ -9131,7 +9149,7 @@ packages:
       integrity: sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   /web3-bzz/1.2.6:
     dependencies:
-      '@types/node': 10.17.55
+      '@types/node': 10.17.56
       got: 9.6.0
       swarm-js: 0.1.39
       underscore: 1.9.1
@@ -9196,7 +9214,7 @@ packages:
   /web3-core/1.2.6:
     dependencies:
       '@types/bn.js': 4.11.6
-      '@types/node': 12.20.6
+      '@types/node': 12.20.7
       web3-core-helpers: 1.2.6
       web3-core-method: 1.2.6
       web3-core-requestmanager: 1.2.6
@@ -9277,7 +9295,7 @@ packages:
       integrity: sha512-TPMc3BW9Iso7H+9w+ytbqHK9wgOmtocyCD3PaAe5Eie50KQ/j7ThA60dGJnxItVo6yyRv5pZAYxPVob9x/fJlg==
   /web3-eth-personal/1.2.6:
     dependencies:
-      '@types/node': 12.20.6
+      '@types/node': 12.20.7
       web3-core: 1.2.6
       web3-core-helpers: 1.2.6
       web3-core-method: 1.2.6
@@ -9417,7 +9435,7 @@ packages:
       integrity: sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==
   /web3/1.2.6:
     dependencies:
-      '@types/node': 12.20.6
+      '@types/node': 12.20.7
       web3-bzz: 1.2.6
       web3-core: 1.2.6
       web3-eth: 1.2.6
@@ -9457,16 +9475,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-  /whatwg-url/8.4.0:
+  /whatwg-url/8.5.0:
     dependencies:
-      lodash.sortby: 4.7.0
+      lodash: 4.17.21
       tr46: 2.0.2
       webidl-conversions: 6.1.0
     dev: false
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==
+      integrity: sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==
   /which-boxed-primitive/1.0.2:
     dependencies:
       is-bigint: 1.0.1
@@ -9833,19 +9851,23 @@ packages:
     dependencies:
       '@ew-did-registry/keys': 0.0.1-alpha.694.1
       '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
-      '@types/express': 4.17.11
-      '@types/node': 14.14.35
-      '@types/yargs': 16.0.0
-      convict: 6.0.1
+      '@types/jest': 26.0.22
+      '@types/node': 14.14.37
+      '@types/yargs': 16.0.1
       eslint: 7.22.0
+      ethers: 4.0.48
+      jest: 26.6.3_ts-node@9.1.1
       rimraf: 3.0.2
+      run-with-testrpc: 0.3.1
+      ts-jest: 26.5.4_jest@26.6.3+typescript@4.2.3
       ts-node: 9.1.1_typescript@4.2.3
       typescript: 4.2.3
+      web3-utils: 1.3.4
       yargs: 16.2.0
     dev: false
     name: '@rush-temp/asset-operator-cli'
     resolution:
-      integrity: sha512-EgnIU8hX7z6fV7SfZQqpc9zbUU0ho465B+rdb5h3ij5blwEiQ0s4/Nt/zmigw01ABDBpuGNgDyfaAUE7IyVSRQ==
+      integrity: sha512-+jvzZNgsVi/cB2cMwiyFMXFEGYIfWDakQ4n1LR+PTVeFLgGXkxWe7RWZ0fzqCbKdghUi2UeMLHR9SAGpsYyQWg==
       tarball: file:projects/asset-operator-cli.tgz
     version: 0.0.0
   file:projects/asset-operator-server.tgz:
@@ -9854,7 +9876,7 @@ packages:
       '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
       '@types/convict': 6.0.1
       '@types/express': 4.17.11
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
       body-parser: 1.19.0
       convict: 6.0.1
       eslint: 7.22.0
@@ -9870,15 +9892,14 @@ packages:
     version: 0.0.0
   file:projects/asset-registrar.tgz_ts-node@9.1.1:
     dependencies:
-      '@ethersproject/bytes': 5.0.11
-      '@ethersproject/contracts': 5.0.12
-      '@ethersproject/providers': 5.0.24
-      '@ethersproject/wallet': 5.0.12
+      '@ethersproject/bytes': 5.1.0
+      '@ethersproject/contracts': 5.1.0
+      '@ethersproject/providers': 5.1.0
+      '@ethersproject/wallet': 5.1.0
       '@ew-did-registry/keys': 0.0.1-alpha.694.1
       '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
       '@typechain/ethers-v4': 4.0.0_ethers@4.0.48+typechain@4.0.3
-      '@types/jest': 26.0.21
-      better-sqlite3: 5.4.3
+      '@types/jest': 26.0.22
       eslint: 7.22.0
       ethers: 4.0.48
       jest: 26.6.3_ts-node@9.1.1
@@ -9894,7 +9915,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-Gi/i1Nrxpe/R6PgpvZdPf8xp+WxskkJvbpC3BWISTQZ4xZbYWQM/nsJNHROiKY6yXOIDI/NrzjCASK+8pZmV2A==
+      integrity: sha512-EPXN/rBfrjd85gJnzuNFtwTz9zPbDRpMXgwHZzy599Yx/BBjt5Pzge9Ea2mg6UHGgI7c0OMiJSXVsb9qL50/7w==
       tarball: file:projects/asset-registrar.tgz
     version: 0.0.0
   file:projects/contract-deployer.tgz:
@@ -9902,13 +9923,14 @@ packages:
       '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
       eslint: 7.22.0
       ethers: 4.0.48
+      pnpm: 5.18.5
       rimraf: 3.0.2
       typechain: 4.0.3_typescript@4.2.3
       typescript: 4.2.3
     dev: false
     name: '@rush-temp/contract-deployer'
     resolution:
-      integrity: sha512-uTEQdS07NwylHwldpBB40D+igRHbLcZTWB/z3ur0L3sRRDYH+sqBoB/8mzTJ8b2/xZti2WbgnviJ5txj3DDpxA==
+      integrity: sha512-oYIRtYjqJDBUE0pToiO+tuIV/CiE16TQ7BX09B7JHj8LMe183m/JqfLqG/vM28n1Nwb7luwKFzKboeK9DMzo8Q==
       tarball: file:projects/contract-deployer.tgz
     version: 0.0.0
   file:projects/did-hydrator.tgz:
@@ -9979,6 +10001,7 @@ packages:
     resolution:
       tarball: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e
     version: 0.6.8
+registry: ''
 specifiers:
   '@ethersproject/bytes': ^5.0.8
   '@ethersproject/contracts': ^5.0.8
@@ -10015,6 +10038,7 @@ specifiers:
   iam-client-lib: 2.0.0-alpha.3
   jest: ~26.6.3
   nats: ^1.4.12
+  pnpm: 5.18.5
   rimraf: ~3.0.2
   run-with-testrpc: ~0.3.1
   ts-jest: ~26.5.4

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9,14 +9,14 @@ dependencies:
   '@ew-did-registry/did-ipfs-store': 0.0.1-alpha.694.1
   '@ew-did-registry/did-resolver-interface': 0.0.1-alpha.694.1
   '@ew-did-registry/keys': 0.0.1-alpha.694.1
-  '@rush-temp/asset-operator-cli': file:projects/asset-operator-cli.tgz
-  '@rush-temp/asset-operator-server': file:projects/asset-operator-server.tgz
-  '@rush-temp/asset-registrar': file:projects/asset-registrar.tgz_ts-node@9.1.1
-  '@rush-temp/contract-deployer': file:projects/contract-deployer.tgz
-  '@rush-temp/did-hydrator': file:projects/did-hydrator.tgz
-  '@rush-temp/key-manager': file:projects/key-manager.tgz
-  '@rush-temp/prequalification-client': file:projects/prequalification-client.tgz
-  '@rush-temp/signer-provider-interface': file:projects/signer-provider-interface.tgz
+  '@rush-temp/ev-asset-operator-cli': file:projects/ev-asset-operator-cli.tgz
+  '@rush-temp/ev-asset-operator-server': file:projects/ev-asset-operator-server.tgz
+  '@rush-temp/ev-contract-deployer': file:projects/ev-contract-deployer.tgz
+  '@rush-temp/ev-did-hydrator': file:projects/ev-did-hydrator.tgz
+  '@rush-temp/ev-key-manager': file:projects/ev-key-manager.tgz
+  '@rush-temp/ev-prequalification': file:projects/ev-prequalification.tgz
+  '@rush-temp/ev-registry': file:projects/ev-registry.tgz_ts-node@9.1.1
+  '@rush-temp/ev-signer-interface': file:projects/ev-signer-interface.tgz
   '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
   '@typechain/ethers-v4': 4.0.0_ethers@4.0.48+typechain@4.0.3
   '@types/convict': 6.0.1
@@ -1692,7 +1692,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  /ajv/8.0.2:
+  /ajv/8.0.3:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -1700,7 +1700,7 @@ packages:
       uri-js: 4.4.1
     dev: false
     resolution:
-      integrity: sha512-V0HGxJd0PiDF0ecHYIesTOqfd1gJguwQUOYfMfAWnRsWQEXfc5ifbUFhD3Wjc+O+y7VAqL+g07prq9gHQ/JOZQ==
+      integrity: sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==
   /ansi-colors/4.1.1:
     dev: false
     engines:
@@ -2275,7 +2275,7 @@ packages:
     dependencies:
       caniuse-lite: 1.0.30001205
       colorette: 1.2.2
-      electron-to-chromium: 1.3.703
+      electron-to-chromium: 1.3.704
       escalade: 3.1.1
       node-releases: 1.1.71
     dev: false
@@ -3125,10 +3125,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.703:
+  /electron-to-chromium/1.3.704:
     dev: false
     resolution:
-      integrity: sha512-SVBVhNB+4zPL+rvtWLw7PZQkw/Eqj1HQZs22xtcqW36+xoifzEOEEDEpkxSMfB6RFeSIOcG00w6z5mSqLr1Y6w==
+      integrity: sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA==
   /elliptic/6.3.3:
     dependencies:
       bn.js: 4.12.0
@@ -4624,7 +4624,7 @@ packages:
       integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   /hmac-drbg/1.0.1:
     dependencies:
-      hash.js: 1.1.3
+      hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     dev: false
@@ -5455,7 +5455,7 @@ packages:
       jest-config: 26.6.3_ts-node@9.1.1
       jest-util: 26.6.2
       jest-validate: 26.6.2
-      prompts: 2.4.0
+      prompts: 2.4.1
       yargs: 15.4.1
     dev: false
     engines:
@@ -7414,7 +7414,7 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-o73CbvQh/OnPFShxHcHxk0baXR2a1m4ozb85ha0H14VEoi/EJJLa9mnPfEWJx9RjA9MLfhdjZ8I6HhWtBa64Ag==
-  /prompts/2.4.0:
+  /prompts/2.4.1:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
@@ -7422,7 +7422,7 @@ packages:
     engines:
       node: '>= 6'
     resolution:
-      integrity: sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==
+      integrity: sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
   /prop-types/15.7.2:
     dependencies:
       loose-envify: 1.4.0
@@ -8560,7 +8560,7 @@ packages:
       integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
   /table/6.0.9:
     dependencies:
-      ajv: 8.0.2
+      ajv: 8.0.3
       is-boolean-object: 1.1.0
       is-number-object: 1.0.4
       is-string: 1.0.5
@@ -9848,7 +9848,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-  file:projects/asset-operator-cli.tgz:
+  file:projects/ev-asset-operator-cli.tgz:
     dependencies:
       '@ew-did-registry/keys': 0.0.1-alpha.694.1
       '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
@@ -9866,12 +9866,12 @@ packages:
       web3-utils: 1.3.4
       yargs: 16.2.0
     dev: false
-    name: '@rush-temp/asset-operator-cli'
+    name: '@rush-temp/ev-asset-operator-cli'
     resolution:
-      integrity: sha512-+jvzZNgsVi/cB2cMwiyFMXFEGYIfWDakQ4n1LR+PTVeFLgGXkxWe7RWZ0fzqCbKdghUi2UeMLHR9SAGpsYyQWg==
-      tarball: file:projects/asset-operator-cli.tgz
+      integrity: sha512-Xn+ePSFHHG1rXbCtt4voXqOBlESjcQVAMKN9ruDYLjhrNBIHiVlKwv/D+jKb2VRgO5Yqe2pyHG4ns1UQaiyjSQ==
+      tarball: file:projects/ev-asset-operator-cli.tgz
     version: 0.0.0
-  file:projects/asset-operator-server.tgz:
+  file:projects/ev-asset-operator-server.tgz:
     dependencies:
       '@ew-did-registry/keys': 0.0.1-alpha.694.1
       '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
@@ -9886,12 +9886,74 @@ packages:
       ts-node: 9.1.1_typescript@4.2.3
       typescript: 4.2.3
     dev: false
-    name: '@rush-temp/asset-operator-server'
+    name: '@rush-temp/ev-asset-operator-server'
     resolution:
-      integrity: sha512-pQ0ySAIswZ5c4mTa7pc8VIyOIRA+qbTaWeohw5hjjftMkjGPPm/d6vP+yo/s+Z7EQ5mjt0DzCP3P2ftSdEUjuA==
-      tarball: file:projects/asset-operator-server.tgz
+      integrity: sha512-QJfJEYOIAbOPKJQ7suoyZRxxyQqDDQOkxmGixCMERJVr3cZU5Kyz0oNKJEcswufpP9AOoEGy11f6fRTiRJoogw==
+      tarball: file:projects/ev-asset-operator-server.tgz
     version: 0.0.0
-  file:projects/asset-registrar.tgz_ts-node@9.1.1:
+  file:projects/ev-contract-deployer.tgz:
+    dependencies:
+      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
+      eslint: 7.22.0
+      ethers: 4.0.48
+      pnpm: 5.18.5
+      rimraf: 3.0.2
+      typechain: 4.0.3_typescript@4.2.3
+      typescript: 4.2.3
+    dev: false
+    name: '@rush-temp/ev-contract-deployer'
+    resolution:
+      integrity: sha512-8/laIdtf+GQi1HQ0FYjuSDVDepvRdb+X0kcOtLhFGZiFIlDk+4MIdJdRNy0Kktt7HIm2TMW223NOr19b0cSmaA==
+      tarball: file:projects/ev-contract-deployer.tgz
+    version: 0.0.0
+  file:projects/ev-did-hydrator.tgz:
+    dependencies:
+      '@ew-did-registry/did': 0.0.1-alpha.694.1
+      '@ew-did-registry/did-document': 0.0.1-alpha.694.1
+      '@ew-did-registry/did-ethr-resolver': 0.0.1-alpha.694.1
+      '@ew-did-registry/did-ipfs-store': 0.0.1-alpha.694.1
+      '@ew-did-registry/did-resolver-interface': 0.0.1-alpha.694.1
+      '@ew-did-registry/keys': 0.0.1-alpha.694.1
+      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
+      eslint: 7.22.0
+      ethers: 4.0.48
+      rimraf: 3.0.2
+      typescript: 4.2.3
+    dev: false
+    name: '@rush-temp/ev-did-hydrator'
+    resolution:
+      integrity: sha512-O7euAITJIen6LqNNxGci0di20Gitjo39LEyzZUg6AfXAqTHBaX0zVysrHk2WwpYHjKuP8ra4vernfTxT9eU+Sw==
+      tarball: file:projects/ev-did-hydrator.tgz
+    version: 0.0.0
+  file:projects/ev-key-manager.tgz:
+    dependencies:
+      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
+      better-sqlite3: 5.4.3
+      eslint: 7.22.0
+      ethers: 4.0.48
+      typescript: 4.2.3
+    dev: false
+    name: '@rush-temp/ev-key-manager'
+    resolution:
+      integrity: sha512-rTzWBUWEZYAxY+Mr3zT9sl/Nny6YbRIaUrE5b0GhaTvQClmD+nprxPL0j5gvhxgNoE5enPlUDRb0303xvVk+Hg==
+      tarball: file:projects/ev-key-manager.tgz
+    version: 0.0.0
+  file:projects/ev-prequalification.tgz:
+    dependencies:
+      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
+      '@types/events': 3.0.0
+      eslint: 7.22.0
+      ethers: 4.0.48
+      iam-client-lib: 2.0.0-alpha.3
+      nats: 1.4.12
+      typescript: 4.2.3
+    dev: false
+    name: '@rush-temp/ev-prequalification'
+    resolution:
+      integrity: sha512-5bOT6NaxUk5VNtOYl+qE9KruDE/Z4SSDxeYU/Eop+Xq82v+du9g4ZpNIauR0Koio9Qigjlr5O8d6vYBUWapcHw==
+      tarball: file:projects/ev-prequalification.tgz
+    version: 0.0.0
+  file:projects/ev-registry.tgz_ts-node@9.1.1:
     dependencies:
       '@ethersproject/bytes': 5.1.0
       '@ethersproject/contracts': 5.1.0
@@ -9912,87 +9974,25 @@ packages:
       typescript: 4.2.3
       web3-utils: 1.3.4
     dev: false
-    id: file:projects/asset-registrar.tgz
-    name: '@rush-temp/asset-registrar'
+    id: file:projects/ev-registry.tgz
+    name: '@rush-temp/ev-registry'
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-e8xiWEHoZLYP9MMwUBNxrNQZpQFj+tYIB/CWVCROKRdGeUpWU5ualcsOQ075K9D9R6UE4o9h8+cjm7zbI9CnMg==
-      tarball: file:projects/asset-registrar.tgz
+      integrity: sha512-mmemQIvN1D1eXJkUCLcjk8omzbok4PGpQ9eqxEyef7jliVYPeJX0C9sFZB977y3iabRJAIw+G3FmcGgdJQG6gQ==
+      tarball: file:projects/ev-registry.tgz
     version: 0.0.0
-  file:projects/contract-deployer.tgz:
-    dependencies:
-      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
-      eslint: 7.22.0
-      ethers: 4.0.48
-      pnpm: 5.18.5
-      rimraf: 3.0.2
-      typechain: 4.0.3_typescript@4.2.3
-      typescript: 4.2.3
-    dev: false
-    name: '@rush-temp/contract-deployer'
-    resolution:
-      integrity: sha512-oYIRtYjqJDBUE0pToiO+tuIV/CiE16TQ7BX09B7JHj8LMe183m/JqfLqG/vM28n1Nwb7luwKFzKboeK9DMzo8Q==
-      tarball: file:projects/contract-deployer.tgz
-    version: 0.0.0
-  file:projects/did-hydrator.tgz:
-    dependencies:
-      '@ew-did-registry/did': 0.0.1-alpha.694.1
-      '@ew-did-registry/did-document': 0.0.1-alpha.694.1
-      '@ew-did-registry/did-ethr-resolver': 0.0.1-alpha.694.1
-      '@ew-did-registry/did-ipfs-store': 0.0.1-alpha.694.1
-      '@ew-did-registry/did-resolver-interface': 0.0.1-alpha.694.1
-      '@ew-did-registry/keys': 0.0.1-alpha.694.1
-      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
-      eslint: 7.22.0
-      ethers: 4.0.48
-      rimraf: 3.0.2
-      typescript: 4.2.3
-    dev: false
-    name: '@rush-temp/did-hydrator'
-    resolution:
-      integrity: sha512-7wAfYKNUcOCUJURRrafXQxAK8n7jlgxMM74tYagBngQUq5BXkFvkDzly4bjwxYNHWxCia7/qEvWuAPdBCt2QwQ==
-      tarball: file:projects/did-hydrator.tgz
-    version: 0.0.0
-  file:projects/key-manager.tgz:
-    dependencies:
-      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
-      better-sqlite3: 5.4.3
-      eslint: 7.22.0
-      ethers: 4.0.48
-      typescript: 4.2.3
-    dev: false
-    name: '@rush-temp/key-manager'
-    resolution:
-      integrity: sha512-ACSheJAo8jet0JW3xua8dtKTyCwsHqUPL62SSSc2NCrl/3mYJk2+YBIC2gsynjbewz5b07K1vQ1vk2bfC1d8nQ==
-      tarball: file:projects/key-manager.tgz
-    version: 0.0.0
-  file:projects/prequalification-client.tgz:
-    dependencies:
-      '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
-      '@types/events': 3.0.0
-      eslint: 7.22.0
-      ethers: 4.0.48
-      iam-client-lib: 2.0.0-alpha.3
-      nats: 1.4.12
-      typescript: 4.2.3
-    dev: false
-    name: '@rush-temp/prequalification-client'
-    resolution:
-      integrity: sha512-tO3tnTRXmAaeWVkObcG6iLaKDDHOXlX7eL55MCV7v62/FqaUE20yYE88F3U1zSlQ7hDJbcBZJJb0jAWOv+Yw6g==
-      tarball: file:projects/prequalification-client.tgz
-    version: 0.0.0
-  file:projects/signer-provider-interface.tgz:
+  file:projects/ev-signer-interface.tgz:
     dependencies:
       '@rushstack/eslint-config': 2.3.2_eslint@7.22.0+typescript@4.2.3
       eslint: 7.22.0
       ethers: 4.0.48
       typescript: 4.2.3
     dev: false
-    name: '@rush-temp/signer-provider-interface'
+    name: '@rush-temp/ev-signer-interface'
     resolution:
-      integrity: sha512-04N7ExgzeWxPv2ZMz2fBD04RQUeyxfej9goD2dl6dmX/Dj+iedYuGqHDGlXx3t3fIxpviujN1ne3oPD9pLxAdA==
-      tarball: file:projects/signer-provider-interface.tgz
+      integrity: sha512-YCpoVfW2J7yo12AdICLo8bGolD97jyuziaVYeZZWyUqxgusqC31qNULXwOFIgUFjyb2kQyzijegr1jhxUj4KnA==
+      tarball: file:projects/ev-signer-interface.tgz
     version: 0.0.0
   github.com/ethereumjs/ethereumjs-abi/1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e:
     dependencies:
@@ -10003,7 +10003,6 @@ packages:
     resolution:
       tarball: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e
     version: 0.6.8
-registry: ''
 specifiers:
   '@ethersproject/bytes': ^5.0.8
   '@ethersproject/contracts': ^5.0.8
@@ -10015,14 +10014,14 @@ specifiers:
   '@ew-did-registry/did-ipfs-store': 0.0.1-alpha.694.1
   '@ew-did-registry/did-resolver-interface': 0.0.1-alpha.694.1
   '@ew-did-registry/keys': 0.0.1-alpha.694.1
-  '@rush-temp/asset-operator-cli': file:./projects/asset-operator-cli.tgz
-  '@rush-temp/asset-operator-server': file:./projects/asset-operator-server.tgz
-  '@rush-temp/asset-registrar': file:./projects/asset-registrar.tgz
-  '@rush-temp/contract-deployer': file:./projects/contract-deployer.tgz
-  '@rush-temp/did-hydrator': file:./projects/did-hydrator.tgz
-  '@rush-temp/key-manager': file:./projects/key-manager.tgz
-  '@rush-temp/prequalification-client': file:./projects/prequalification-client.tgz
-  '@rush-temp/signer-provider-interface': file:./projects/signer-provider-interface.tgz
+  '@rush-temp/ev-asset-operator-cli': file:./projects/ev-asset-operator-cli.tgz
+  '@rush-temp/ev-asset-operator-server': file:./projects/ev-asset-operator-server.tgz
+  '@rush-temp/ev-contract-deployer': file:./projects/ev-contract-deployer.tgz
+  '@rush-temp/ev-did-hydrator': file:./projects/ev-did-hydrator.tgz
+  '@rush-temp/ev-key-manager': file:./projects/ev-key-manager.tgz
+  '@rush-temp/ev-prequalification': file:./projects/ev-prequalification.tgz
+  '@rush-temp/ev-registry': file:./projects/ev-registry.tgz
+  '@rush-temp/ev-signer-interface': file:./projects/ev-signer-interface.tgz
   '@rushstack/eslint-config': ~2.3.2
   '@typechain/ethers-v4': ~4.0.0
   '@types/convict': ~6.0.1

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -87,4 +87,13 @@
   //    */
   //   "exemptFromRushChange": false
   // }
+
+
+  // Libraries are in lockStep so that it will be easier in future to publish an umbrellla package
+  {
+    "policyName": "libraries",
+    "definitionName": "lockStepVersion",
+    "version": "1.0.0",
+    "nextBump": "minor"
+  }
 ]

--- a/libraries/asset-registrar/package.json
+++ b/libraries/asset-registrar/package.json
@@ -28,6 +28,7 @@
     "@typechain/ethers-v4": "~4.0.0",
     "@types/jest": "~26.0.21",
     "eslint": "~7.22.0",
+    "ganache-cli": "^6.4.2",
     "jest": "~26.6.3",
     "rimraf": "~3.0.2",
     "run-with-testrpc": "~0.3.1",

--- a/libraries/asset-registrar/package.json
+++ b/libraries/asset-registrar/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ev-dashboard-client/asset-registrar",
+  "name": "@energyweb/ev-registry",
   "version": "1.0.0",
   "description": "API for AssetOperators to enable their assets to register in the ev-dashboard.",
   "main": "dist/src/ev-registry.js",
@@ -10,6 +10,14 @@
     "test:watch": "pnpm run start-rpc -- \"jest --coverage --watchAll\"",
     "test": "pnpm run start-rpc -- \"jest --coverage --no-cache\"",
     "start-rpc": "run-with-testrpc -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000"
+  },
+  "homepage": "https://github.com/energywebfoundation/ev-dashboard-client/#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/ev-dashboard-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/energywebfoundation/ev-dashboard-client/issues"
   },
   "author": "Energy Web",
   "license": "GPL-3.0-or-later",
@@ -23,7 +31,7 @@
     "web3-utils": "^1.3.0"
   },
   "devDependencies": {
-    "@ev-dashboard-client/contract-deployer": "1.0.0",
+    "@energyweb/ev-contract-deployer": "1.0.0",
     "@rushstack/eslint-config": "~2.3.2",
     "@typechain/ethers-v4": "~4.0.0",
     "@types/jest": "~26.0.21",

--- a/libraries/asset-registrar/package.json
+++ b/libraries/asset-registrar/package.json
@@ -34,5 +34,9 @@
     "typescript": "~4.2.3",
     "typechain": "~4.0.3",
     "ts-jest": "~26.5.4"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/libraries/asset-registrar/test/EvRegistry.test.ts
+++ b/libraries/asset-registrar/test/EvRegistry.test.ts
@@ -4,7 +4,7 @@ import {
   GANACHE_PORT,
   evDashboardRegistry,
   ocnRegistry
-} from '@ev-dashboard-client/contract-deployer';
+} from '@energyweb/ev-contract-deployer';
 import { EvRegistry } from '../src/ev-registry';
 import { Keys } from '@ew-did-registry/keys';
 import { toHex } from 'web3-utils';

--- a/libraries/did-hydrator/package.json
+++ b/libraries/did-hydrator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ev-dashboard-client/did-hydrator",
+  "name": "@energyweb/ev-did-hydrator",
   "version": "1.0.0",
   "description": "API for AssetOperators to enable their assets to participate in the ev-dashboard.",
   "homepage": "https://github.com/energywebfoundation/ev-dashboard-client#readme",
@@ -17,7 +17,7 @@
   "author": "Energy Web",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@ev-dashboard-client/signer-provider-interface": "1.0.0",
+    "@energyweb/ev-signer-interface": "1.0.0",
     "@ew-did-registry/did": "0.0.1-alpha.694.1",
     "@ew-did-registry/did-document": "0.0.1-alpha.694.1",
     "@ew-did-registry/did-ethr-resolver": "0.0.1-alpha.694.1",

--- a/libraries/did-hydrator/package.json
+++ b/libraries/did-hydrator/package.json
@@ -2,6 +2,14 @@
   "name": "@ev-dashboard-client/did-hydrator",
   "version": "1.0.0",
   "description": "API for AssetOperators to enable their assets to participate in the ev-dashboard.",
+  "homepage": "https://github.com/energywebfoundation/ev-dashboard-client#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/ev-dashboard-client"
+  },
+  "bugs": {
+    "url": "https://github.com/energywebfoundation/ev-dashboard-client/issues"
+  },
   "main": "dist/DID.js",
   "scripts": {
     "build": "rimraf dist && tsc"
@@ -23,5 +31,9 @@
     "eslint": "~7.22.0",
     "rimraf": "~3.0.2",
     "typescript": "~4.2.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/libraries/did-hydrator/src/DID.ts
+++ b/libraries/did-hydrator/src/DID.ts
@@ -4,7 +4,7 @@ import { IResolverSettings, ProviderTypes } from '@ew-did-registry/did-resolver-
 import { Keys } from '@ew-did-registry/keys';
 import { Wallet } from 'ethers';
 import { JsonRpcProvider } from 'ethers/providers';
-import { ISignerProvider } from '@ev-dashboard-client/signer-provider-interface';
+import { ISignerProvider } from '@energyweb/ev-signer-interface';
 import { getDIDFromAddress } from './utils';
 import { Methods } from '@ew-did-registry/did';
 

--- a/libraries/key-manager/package.json
+++ b/libraries/key-manager/package.json
@@ -17,5 +17,9 @@
     "@rushstack/eslint-config": "~2.3.2",
     "eslint": "~7.22.0",
     "typescript": "~4.2.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/libraries/key-manager/package.json
+++ b/libraries/key-manager/package.json
@@ -1,15 +1,23 @@
 {
-  "name": "@ev-dashboard-client/key-manager",
+  "name": "@energyweb/ev-key-manager",
   "version": "1.0.0",
   "description": "Optional component that can be used to centrally manage keys",
   "main": "dist/KeyManager.js",
   "scripts": {
     "build": "tsc"
   },
+  "homepage": "https://github.com/energywebfoundation/ev-dashboard-client/#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/ev-dashboard-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/energywebfoundation/ev-dashboard-client/issues"
+  },
   "author": "Energy Web",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@ev-dashboard-client/signer-provider-interface": "1.0.0",
+    "@energyweb/ev-signer-interface": "1.0.0",
     "better-sqlite3": "^5.4.3",
     "ethers": "^4.0.48"
   },

--- a/libraries/key-manager/src/KeyManager.ts
+++ b/libraries/key-manager/src/KeyManager.ts
@@ -1,6 +1,6 @@
 import * as sqlite3 from 'better-sqlite3';
 import { Wallet } from 'ethers';
-import { ISignerProvider } from '@ev-dashboard-client/signer-provider-interface';
+import { ISignerProvider } from '@energyweb/ev-signer-interface';
 import { IKeyPair } from './IKeyPair';
 
 export class KeyManager implements ISignerProvider {

--- a/libraries/prequalification-client/package.json
+++ b/libraries/prequalification-client/package.json
@@ -20,5 +20,9 @@
     "@types/events": "~3.0.0",
     "eslint": "~7.22.0",
     "typescript": "~4.2.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/libraries/prequalification-client/package.json
+++ b/libraries/prequalification-client/package.json
@@ -1,16 +1,24 @@
 {
-  "name": "@ev-dashboard-client/prequalification-client",
+  "name": "@energyweb/ev-prequalification",
   "version": "1.0.0",
   "description": "listens for prequalification claim events on behalf of assets",
   "main": "dist/prequalification-client.js",
   "scripts": {
     "build": "rimraf dist && tsc"
   },
+  "homepage": "https://github.com/energywebfoundation/ev-dashboard-client/#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/ev-dashboard-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/energywebfoundation/ev-dashboard-client/issues"
+  },
   "author": "Energy Web",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@ev-dashboard-client/key-manager": "1.0.0",
-    "@ev-dashboard-client/signer-provider-interface": "1.0.0",
+    "@energyweb/ev-key-manager": "1.0.0",
+    "@energyweb/ev-signer-interface": "1.0.0",
     "ethers": "^4.0.48",
     "iam-client-lib": "2.0.0-alpha.3",
     "nats": "^1.4.12"

--- a/libraries/prequalification-client/src/PrequalificationClient.ts
+++ b/libraries/prequalification-client/src/PrequalificationClient.ts
@@ -1,6 +1,6 @@
 import { NATS_EXCHANGE_TOPIC } from 'iam-client-lib';
 import { Client } from 'nats';
-import { ISignerProvider } from '@ev-dashboard-client/signer-provider-interface';
+import { ISignerProvider } from '@energyweb/ev-signer-interface';
 import { Asset, IPrequalificationRole } from './Asset';
 import { IamClientLibFactory, IamClientLibFactoryParams } from './IamClientLibFactory';
 import { NatsConnection } from './NatsConnection';

--- a/libraries/signer-provider-interface/package.json
+++ b/libraries/signer-provider-interface/package.json
@@ -15,5 +15,9 @@
     "@rushstack/eslint-config": "~2.3.2",
     "eslint": "~7.22.0",
     "typescript": "~4.2.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/libraries/signer-provider-interface/package.json
+++ b/libraries/signer-provider-interface/package.json
@@ -1,10 +1,18 @@
 {
-  "name": "@ev-dashboard-client/signer-provider-interface",
+  "name": "@energyweb/ev-signer-interface",
   "version": "1.0.0",
   "description": "An interface which provides access to a Signer for a given DID",
   "main": "dist/ISignerProvider.js",
   "scripts": {
     "build": "tsc"
+  },
+  "homepage": "https://github.com/energywebfoundation/ev-dashboard-client/#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/ev-dashboard-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/energywebfoundation/ev-dashboard-client/issues"
   },
   "author": "Energy Web",
   "license": "GPL-3.0-or-later",

--- a/rush.json
+++ b/rush.json
@@ -418,42 +418,42 @@
     // },
     //
     {
-      "packageName": "@ev-dashboard-client/asset-registrar",
+      "packageName": "@energyweb/ev-registry",
       "projectFolder": "libraries/asset-registrar",
       "shouldPublish": true
     },
     {
-      "packageName": "@ev-dashboard-client/did-hydrator",
+      "packageName": "@energyweb/ev-did-hydrator",
       "projectFolder": "libraries/did-hydrator",
       "shouldPublish": true
     },
     {
-      "packageName": "@ev-dashboard-client/key-manager",
+      "packageName": "@energyweb/ev-key-manager",
       "projectFolder": "libraries/key-manager",
       "shouldPublish": true
     },
     {
-      "packageName": "@ev-dashboard-client/prequalification-client",
+      "packageName": "@energyweb/ev-prequalification",
       "projectFolder": "libraries/prequalification-client",
       "shouldPublish": true
     },
     {
-      "packageName": "@ev-dashboard-client/signer-provider-interface",
+      "packageName": "@energyweb/ev-signer-interface",
       "projectFolder": "libraries/signer-provider-interface",
       "shouldPublish": true
     },
     {
-      "packageName": "@ev-dashboard-client/asset-operator-server",
+      "packageName": "@energyweb/ev-asset-operator-server",
       "projectFolder": "apps/asset-operator-server",
       "shouldPublish": true
     },
     {
-      "packageName": "@ev-dashboard-client/asset-operator-cli",
+      "packageName": "@energyweb/ev-asset-operator-cli",
       "projectFolder": "apps/asset-operator-cli",
       "shouldPublish": true
     },
     {
-      "packageName": "@ev-dashboard-client/contract-deployer",
+      "packageName": "@energyweb/ev-contract-deployer",
       "projectFolder": "tools/contract-deployer"
     }
     //

--- a/rush.json
+++ b/rush.json
@@ -420,27 +420,27 @@
     {
       "packageName": "@energyweb/ev-registry",
       "projectFolder": "libraries/asset-registrar",
-      "shouldPublish": true
+      "versionPolicyName": "libraries"
     },
     {
       "packageName": "@energyweb/ev-did-hydrator",
       "projectFolder": "libraries/did-hydrator",
-      "shouldPublish": true
+      "versionPolicyName": "libraries"
     },
     {
       "packageName": "@energyweb/ev-key-manager",
       "projectFolder": "libraries/key-manager",
-      "shouldPublish": true
+      "versionPolicyName": "libraries"
     },
     {
       "packageName": "@energyweb/ev-prequalification",
       "projectFolder": "libraries/prequalification-client",
-      "shouldPublish": true
+      "versionPolicyName": "libraries"
     },
     {
       "packageName": "@energyweb/ev-signer-interface",
       "projectFolder": "libraries/signer-provider-interface",
-      "shouldPublish": true
+      "versionPolicyName": "libraries"
     },
     {
       "packageName": "@energyweb/ev-asset-operator-server",

--- a/tools/contract-deployer/package.json
+++ b/tools/contract-deployer/package.json
@@ -18,6 +18,7 @@
     "eslint": "~7.22.0",
     "typescript": "~4.2.3",
     "typechain": "~4.0.3",
-    "rimraf": "~3.0.2"
+    "rimraf": "~3.0.2",
+    "pnpm": "5.18.5"
   }
 }

--- a/tools/contract-deployer/package.json
+++ b/tools/contract-deployer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ev-dashboard-client/contract-deployer",
+  "name": "@energyweb/ev-contract-deployer",
   "version": "1.0.0",
   "description": "Deploys contracts to local blockchain for use in tests",
   "main": "dist/src/setup_contracts.js",


### PR DESCRIPTION
- Added GitHub CI
- Package names changed as below
```
@ev-dashboard-client/asset-registrar -> @energyweb/ev-registry
@ev-dashboard-client/did-hydrator -> @energyweb/ev-did-hydrator
@ev-dashboard-client/key-manager -> @energyweb/ev-key-manager
@ev-dashboard-client/prequalification-client -> @energyweb/ev-prequalification
@ev-dashboard-client/signer-provider-interface -> @energyweb/ev-signer-interface
@ev-dashboard-client/asset-operator-server -> @energyweb/ev-operator-server
@ev-dashboard-client/asset-operator-cli -> @energyweb/ev-operator-cli
@ev-dashboard-client/contract-deployer -> @energyweb/ev-contract-deployer [this one will not be published]
```
- Packages published through CI
https://www.npmjs.com/package/@energyweb/ev-asset-operator-server
https://www.npmjs.com/package/@energyweb/ev-asset-operator-cli
https://www.npmjs.com/package/@energyweb/ev-registry
https://www.npmjs.com/package/@energyweb/ev-did-hydrator
https://www.npmjs.com/package/@energyweb/ev-key-manager
https://www.npmjs.com/package/@energyweb/ev-prequalification
https://www.npmjs.com/package/@energyweb/ev-signer-interface
- version policy not applied (@jrhender can you please take a look)

- `publish` branch needs to be created to publish npm packages via CI.